### PR TITLE
Remove extraneous traits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ We are using tagged releases on master to indicate milestones. There is no devel
 * Branches that implement new features should be named `feature/<the-feature-name>`
 * Branches that improve documentation should be named `doc/<what-docs-are-updated>`. Of course, feature branches will include lots of documentation as well - this name is only for branches that exist solely to update documentation.
 * Branches that fix bugs on a tagged release should be named `hotfix/<what's-being-fixed>`
+* Refactors should be named `refactor/<what's-refactored-and-the-end-result>`
 
 #### Commit Messages
 Commit messages should start with a brief description of what the commit does - a verb phrase, like "add CONTRIBUTING.md" or "test foo under bar conditions". This verb phrase should indicate what changes will be caused by applying the code to the codebase. Then, if there is more to your commit than what you could say in the header, list everything else in bullets after two newline. For example:

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -12,7 +12,7 @@ This holds the agents (classes that extend `TAgent`), and supporting classes suc
 Implements islands and clusters of islands. The main point of this package are the classes that extend `TEvolutionaryProcess`. These classes are ready-to-use implementations of evolutionary processes, that only need to have creators, fitness functions, etc. plugged in to start solving problems. Each island has its own population.
 
 #### [`island/population`](src/main/scala/com/evvo/island/population/)
-Holds `TPopulation`, `Population`, and the classes required to support them. The population is a set of scored ('`TScored`') solutions, where uniqueness and equality are (by default) measured by the score and not the solution itself. This is for speed (we can hash a smaller piece of data - the score mapping), and for speed (because we have fewer solutions in the population, and anything with duplicate scores should be just as good as a solution).
+Holds `Population`, `StandardPopulation`, and the classes required to support them. The population is a set of scored ('`Scored`') solutions, where uniqueness and equality are (by default) measured by the score and not the solution itself. This is for speed (we can hash a smaller piece of data - the score mapping), and for speed (because we have fewer solutions in the population, and anything with duplicate scores should be just as good as a solution).
 
 
 -------------------------------------------------------------------------------

--- a/examples/main/scala/com/evvo/professormatching/ProfessorMatching.scala
+++ b/examples/main/scala/com/evvo/professormatching/ProfessorMatching.scala
@@ -102,9 +102,9 @@ object ProfessorMatching {
       .addObjective(Objective(sumProfessorCoursePreferences, "Course", Maximize))
       .addObjective(Objective(sumProfessorNumPrepsPreferences, "#Prep", Maximize))
       .addObjective(Objective(sumProfessorSectionCountPreferences, "#Section", Maximize))
-      .addCreator(CreatorFunc(validScheduleCreator, "creator"))
-      .addMutator(MutatorFunc(swapTwoCourses, "swapTwoCourses"))
-      .addMutator(MutatorFunc(balanceCourseload, "balanceCourseload"))
+      .addCreator(CreatorFunction(validScheduleCreator, "creator"))
+      .addMutator(MutatorFunction(swapTwoCourses, "swapTwoCourses"))
+      .addMutator(MutatorFunction(balanceCourseload, "balanceCourseload"))
 
     val config = ConfigFactory
       .parseFile(new File("src/main/resources/application.conf"))

--- a/src/main/scala/com/evvo/agent/agent.scala
+++ b/src/main/scala/com/evvo/agent/agent.scala
@@ -1,14 +1,14 @@
 package com.evvo.agent
 
 import akka.event.LoggingAdapter
-import com.evvo.island.population.TPopulation
+import com.evvo.island.population.Population
 
 import scala.concurrent.duration._
 
 /**
   * The parent trait for all types of evolutionary agents.
   */
-trait TAgent[Sol] {
+trait Agent[Sol] {
   def start(): Unit
 
   def stop(): Unit
@@ -16,11 +16,11 @@ trait TAgent[Sol] {
   def numInvocations: Int
 }
 
-abstract class AAgent[Sol](private val strategy: TAgentStrategy,
-                           private val population: TPopulation[Sol],
+abstract class AAgent[Sol](private val strategy: AgentStrategy,
+                           private val population: Population[Sol],
                            protected val name: String)
                           (private implicit val logger: LoggingAdapter)
-  extends TAgent[Sol] {
+  extends Agent[Sol] {
 
   var numInvocations: Int = 0
 

--- a/src/main/scala/com/evvo/agent/creator.scala
+++ b/src/main/scala/com/evvo/agent/creator.scala
@@ -1,17 +1,15 @@
 package com.evvo.agent
 
 import akka.event.LoggingAdapter
-import com.evvo.island.population.TPopulation
+import com.evvo.island.population.Population
 import scala.concurrent.duration._
 
 
-trait TCreatorAgent[Sol] extends TAgent[Sol]
-
-case class CreatorAgent[Sol](create: TCreatorFunc[Sol],
-                             population: TPopulation[Sol],
-                             strategy: TAgentStrategy = CreatorAgentDefaultStrategy())
+case class CreatorAgent[Sol](create: CreatorFunction[Sol],
+                             population: Population[Sol],
+                             strategy: AgentStrategy = CreatorAgentDefaultStrategy())
                             (implicit val logger: LoggingAdapter)
-  extends AAgent[Sol](strategy, population, create.name)(logger) with TCreatorAgent[Sol] {
+  extends AAgent[Sol](strategy, population, create.name)(logger) {
 
   override protected def step(): Unit = {
     val toAdd = create.create()
@@ -21,8 +19,8 @@ case class CreatorAgent[Sol](create: TCreatorFunc[Sol],
   override def toString: String = s"CreatorAgent[$name]"
 }
 
-case class CreatorAgentDefaultStrategy() extends TAgentStrategy {
-  override def waitTime(populationInformation: TPopulationInformation): Duration = {
+case class CreatorAgentDefaultStrategy() extends AgentStrategy {
+  override def waitTime(populationInformation: PopulationInformation): Duration = {
     val n = populationInformation.numSolutions
     if (n > 300) {
       1000.millis // they have 1000 solutions, they're probably set.

--- a/src/main/scala/com/evvo/agent/defaults/defaults.scala
+++ b/src/main/scala/com/evvo/agent/defaults/defaults.scala
@@ -8,9 +8,10 @@
   */
 package com.evvo.agent.defaults
 
-import com.evvo.island.population.{Maximize, Minimize, ParetoFrontier, TScored}
 import com.evvo.DeletorFunctionType
-import com.evvo.agent.TDeletorFunc
+import com.evvo.agent.DeletorFunction
+import com.evvo.island.population
+import com.evvo.island.population.{Maximize, Minimize, ParetoFrontier, Scored}
 
 /**
   * A deletor that deletes the dominated set, in a group of size `groupSize`
@@ -18,19 +19,19 @@ import com.evvo.agent.TDeletorFunc
   * @param numInputs the number of solutions to pull at a time
   */
 case class DeleteDominated[Sol](numInputs: Int = 32) // scalastyle:ignore magic.number
-  extends TDeletorFunc[Sol] {
-  override val delete: DeletorFunctionType[Sol] = (sols: IndexedSeq[TScored[Sol]]) => {
-    val nonDominatedSet = ParetoFrontier(sols.toSet).solutions
+  extends DeletorFunction[Sol] {
+  override val delete: DeletorFunctionType[Sol] = (sols: IndexedSeq[Scored[Sol]]) => {
+    val nonDominatedSet = population.ParetoFrontier(sols.toSet).solutions
     sols.filterNot(elem => nonDominatedSet.contains(elem))
   }
   override val name = "DeleteDominated"
   override val shouldRunWithPartialInput: Boolean = true
 }
 
-case class DeleteWorstHalfByRandomObjective[Sol](numInputs: Int = 32)  // scalastyle:ignore magic.number
-  extends TDeletorFunc[Sol] {
+case class DeleteWorstHalfByRandomObjective[Sol](numInputs: Int = 32) // scalastyle:ignore magic.number
+  extends DeletorFunction[Sol] {
 
-  override val delete: DeletorFunctionType[Sol] = (s: IndexedSeq[TScored[Sol]]) => {
+  override val delete: DeletorFunctionType[Sol] = (s: IndexedSeq[Scored[Sol]]) => {
     if (s.isEmpty) {
       s
     } else {

--- a/src/main/scala/com/evvo/agent/deletor.scala
+++ b/src/main/scala/com/evvo/agent/deletor.scala
@@ -1,16 +1,14 @@
 package com.evvo.agent
 
 import akka.event.LoggingAdapter
-import com.evvo.island.population.TPopulation
+import com.evvo.island.population.Population
 import scala.concurrent.duration._
 
-trait TDeletorAgent[Sol] extends TAgent[Sol]
-
-case class DeletorAgent[Sol](delete: TDeletorFunc[Sol],
-                             population: TPopulation[Sol],
-                             strategy: TAgentStrategy = DeletorAgentDefaultStrategy())
+case class DeletorAgent[Sol](delete: DeletorFunction[Sol],
+                             population: Population[Sol],
+                             strategy: AgentStrategy = DeletorAgentDefaultStrategy())
                             (implicit val logger: LoggingAdapter)
-  extends AAgent[Sol](strategy, population, delete.name)(logger) with TDeletorAgent[Sol] {
+  extends AAgent[Sol](strategy, population, delete.name)(logger) {
 
   override protected def step(): Unit = {
     val in = population.getSolutions(delete.numInputs)
@@ -27,8 +25,8 @@ case class DeletorAgent[Sol](delete: TDeletorFunc[Sol],
   override def toString: String = s"DeletorAgent[$name]"
 }
 
-case class DeletorAgentDefaultStrategy() extends TAgentStrategy {
-  override def waitTime(populationInformation: TPopulationInformation): Duration = {
+case class DeletorAgentDefaultStrategy() extends AgentStrategy {
+  override def waitTime(populationInformation: PopulationInformation): Duration = {
     if (populationInformation.numSolutions < 100) {
       30.millis // give creators a chance!
     } else {

--- a/src/main/scala/com/evvo/agent/mutator.scala
+++ b/src/main/scala/com/evvo/agent/mutator.scala
@@ -1,21 +1,20 @@
 package com.evvo.agent
 
 import akka.event.LoggingAdapter
-import com.evvo.island.population.TPopulation
+import com.evvo.island.population.Population
 
 import scala.concurrent.duration._
 
-trait TMutatorAgent[Sol] extends TAgent[Sol]
 
-case class MutatorAgent[Sol](mutate: TMutatorFunc[Sol],
-                             population: TPopulation[Sol],
-                             strategy: TAgentStrategy = MutatorAgentDefaultStrategy())
+case class MutatorAgent[Sol](mutate: MutatorFunction[Sol],
+                             population: Population[Sol],
+                             strategy: AgentStrategy = MutatorAgentDefaultStrategy())
                             (implicit val logger: LoggingAdapter)
-  extends AAgent[Sol](strategy, population, mutate.name)(logger) with TMutatorAgent[Sol] {
+  extends AAgent[Sol](strategy, population, mutate.name)(logger) {
 
   override protected def step(): Unit = {
     val in = population.getSolutions(mutate.numInputs)
-    if (mutate.shouldRunOnPartialInput || in.length == mutate.numInputs) {
+    if (mutate.shouldRunWithPartialInput || in.length == mutate.numInputs) {
       val mutatedSolutions = mutate(in)
       population.addSolutions(mutatedSolutions)
     } else {
@@ -25,12 +24,11 @@ case class MutatorAgent[Sol](mutate: TMutatorFunc[Sol],
   }
 
   override def toString: String = s"MutatorAgent[$name, $numInvocations]"
-
 }
 
-case class MutatorAgentDefaultStrategy() extends TAgentStrategy {
+case class MutatorAgentDefaultStrategy() extends AgentStrategy {
   // TODO this is bad. fix it.
-  override def waitTime(populationInformation: TPopulationInformation): Duration = {
+  override def waitTime(populationInformation: PopulationInformation): Duration = {
     0.millis
   }
 }

--- a/src/main/scala/com/evvo/agent/strategy.scala
+++ b/src/main/scala/com/evvo/agent/strategy.scala
@@ -7,9 +7,9 @@ import scala.concurrent.duration._
   * Given some information, returns how long to wait between each invocation of the
   * agent's task.
   */
-trait TAgentStrategy {
+trait AgentStrategy {
   // TODO returning a duration is arbitrary, find a better calling API/return type
-  def waitTime(populationInformation: TPopulationInformation): Duration
+  def waitTime(populationInformation: PopulationInformation): Duration
 }
 
 /**
@@ -17,8 +17,4 @@ trait TAgentStrategy {
   * between the population and strategies of agents. Provides enough information
   * for agents to base their decisions on.
   */
-trait TPopulationInformation {
-  def numSolutions: Int
-}
-
-case class PopulationInformation(numSolutions: Int) extends TPopulationInformation
+case class PopulationInformation(numSolutions: Int)

--- a/src/main/scala/com/evvo/island/EvvoIsland.scala
+++ b/src/main/scala/com/evvo/island/EvvoIsland.scala
@@ -4,30 +4,30 @@ import java.util.Calendar
 
 import akka.actor.{ActorSystem, Props}
 import akka.event.LoggingAdapter
+import com.evvo.agent._
+import com.evvo.island.population.{Minimize, Objective, ParetoFrontier, Population, StandardPopulation}
 import com.evvo.{CreatorFunctionType, DeletorFunctionType, MutatorFunctionType, ObjectiveFunctionType}
-import com.evvo.agent.{CreatorAgent, CreatorFunc, DeletorAgent, DeletorFunc, MutatorAgent, MutatorFunc, TCreatorFunc, TDeletorFunc, TMutatorFunc}
-import com.evvo.island.population.{Minimize, Objective, Population, TObjective, TParetoFrontier}
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 
 class EvvoIsland[Sol]
 (
-  creators: Vector[TCreatorFunc[Sol]],
-  mutators: Vector[TMutatorFunc[Sol]],
-  deletors: Vector[TDeletorFunc[Sol]],
-  fitnesses: Vector[TObjective[Sol]])
+  creators: Vector[CreatorFunction[Sol]],
+  mutators: Vector[MutatorFunction[Sol]],
+  deletors: Vector[DeletorFunction[Sol]],
+  fitnesses: Vector[Objective[Sol]])
 (implicit log: LoggingAdapter)
-  extends TEvolutionaryProcess[Sol] {
+  extends EvolutionaryProcess[Sol] {
 
-  private val pop = Population(fitnesses)
+  private val pop: Population[Sol] = StandardPopulation(fitnesses)
   private val creatorAgents = creators.map(c => CreatorAgent(c, pop))
   private val mutatorAgents = mutators.map(m => MutatorAgent(m, pop))
   private val deletorAgents = deletors.map(d => DeletorAgent(d, pop))
 
-  override def runAsync(terminationCriteria: TTerminationCriteria)
+  override def runAsync(terminationCriteria: TerminationCriteria)
   : Future[Unit] = {
     Future {
       log.info(s"Island running with terminationCriteria=${terminationCriteria}")
@@ -53,11 +53,11 @@ class EvvoIsland[Sol]
     }
   }
 
-  def runBlocking(terminationCriteria: TTerminationCriteria): Unit = {
+  def runBlocking(terminationCriteria: TerminationCriteria): Unit = {
     Await.result(this.runAsync(terminationCriteria), Duration.Inf)
   }
 
-  override def currentParetoFrontier(): TParetoFrontier[Sol] = {
+  override def currentParetoFrontier(): ParetoFrontier[Sol] = {
     pop.getParetoFrontier()
   }
 
@@ -89,16 +89,16 @@ object EvvoIsland {
   */
 case class EvvoIslandBuilder[Sol]
 (
-  creators: Set[TCreatorFunc[Sol]] = Set[TCreatorFunc[Sol]](),
-  mutators: Set[TMutatorFunc[Sol]] = Set[TMutatorFunc[Sol]](),
-  deletors: Set[TDeletorFunc[Sol]] = Set[TDeletorFunc[Sol]](),
-  objectives: Set[TObjective[Sol]] = Set[TObjective[Sol]]()
+  creators: Set[CreatorFunction[Sol]] = Set[CreatorFunction[Sol]](),
+  mutators: Set[MutatorFunction[Sol]] = Set[MutatorFunction[Sol]](),
+  deletors: Set[DeletorFunction[Sol]] = Set[DeletorFunction[Sol]](),
+  objectives: Set[Objective[Sol]] = Set[Objective[Sol]]()
 ) {
   def addCreatorFromFunction(creatorFunc: CreatorFunctionType[Sol]): EvvoIslandBuilder[Sol] = {
     this.copy(creators = creators + CreatorFunc(creatorFunc, creatorFunc.toString))
   }
 
-  def addCreator(creatorFunc: TCreatorFunc[Sol]): EvvoIslandBuilder[Sol] = {
+  def addCreator(creatorFunc: CreatorFunction[Sol]): EvvoIslandBuilder[Sol] = {
     this.copy(creators = creators + creatorFunc)
   }
 
@@ -106,7 +106,7 @@ case class EvvoIslandBuilder[Sol]
     this.copy(mutators = mutators + MutatorFunc(mutatorFunc, mutatorFunc.toString))
   }
 
-  def addMutator(mutatorFunc: TMutatorFunc[Sol]): EvvoIslandBuilder[Sol] = {
+  def addMutator(mutatorFunc: MutatorFunction[Sol]): EvvoIslandBuilder[Sol] = {
     this.copy(mutators = mutators + mutatorFunc)
   }
 
@@ -114,7 +114,7 @@ case class EvvoIslandBuilder[Sol]
     this.copy(deletors = deletors + DeletorFunc(deletorFunc, deletorFunc.toString))
   }
 
-  def addDeletor(deletorFunc: TDeletorFunc[Sol]): EvvoIslandBuilder[Sol] = {
+  def addDeletor(deletorFunc: DeletorFunction[Sol]): EvvoIslandBuilder[Sol] = {
     this.copy(deletors = deletors + deletorFunc)
   }
 
@@ -139,7 +139,7 @@ case class EvvoIslandBuilder[Sol]
       objectives.toVector))
   }
 
-  def buildLocalEvvo(): TEvolutionaryProcess[Sol] = {
+  def buildLocalEvvo(): EvolutionaryProcess[Sol] = {
     new LocalEvvoIsland[Sol](
       creators.toVector,
       mutators.toVector,

--- a/src/main/scala/com/evvo/island/EvvoIslandActor.scala
+++ b/src/main/scala/com/evvo/island/EvvoIslandActor.scala
@@ -1,15 +1,14 @@
 package com.evvo.island
 
-import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Address, PoisonPill, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, PoisonPill, Props}
 import akka.event.{LoggingAdapter, LoggingReceive}
 import akka.pattern.ask
 import akka.util.Timeout
 import com.evvo.agent._
+import com.evvo.island.population.{Objective, ParetoFrontier}
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import com.evvo.island.population.{Maximize, Minimize, Objective, Population, TObjective, TParetoFrontier}
+import scala.concurrent.{Await, Future}
 
 
 // for messages
@@ -22,12 +21,12 @@ import com.evvo.island.EvvoIslandActor._
   */
 class EvvoIslandActor[Sol]
 (
-  creators: Vector[TCreatorFunc[Sol]],
-  mutators: Vector[TMutatorFunc[Sol]],
-  deletors: Vector[TDeletorFunc[Sol]],
-  fitnesses: Vector[TObjective[Sol]]
+  creators: Vector[CreatorFunction[Sol]],
+  mutators: Vector[MutatorFunction[Sol]],
+  deletors: Vector[DeletorFunction[Sol]],
+  fitnesses: Vector[Objective[Sol]]
 )
-  extends Actor with TEvolutionaryProcess[Sol] with ActorLogging {
+  extends Actor with EvolutionaryProcess[Sol] with ActorLogging {
   implicit val logger: LoggingAdapter = log
 
   val island = new EvvoIsland[Sol](creators, mutators, deletors, fitnesses)
@@ -39,15 +38,15 @@ class EvvoIslandActor[Sol]
   })
 
 
-  override def runBlocking(terminationCriteria: TTerminationCriteria): Unit = {
+  override def runBlocking(terminationCriteria: TerminationCriteria): Unit = {
     island.runBlocking(terminationCriteria)
   }
 
-  override def runAsync(terminationCriteria: TTerminationCriteria): Future[Unit] = {
+  override def runAsync(terminationCriteria: TerminationCriteria): Future[Unit] = {
     island.runAsync(terminationCriteria)
   }
 
-  override def currentParetoFrontier(): TParetoFrontier[Sol] = {
+  override def currentParetoFrontier(): ParetoFrontier[Sol] = {
     island.currentParetoFrontier()
   }
 
@@ -67,12 +66,12 @@ object EvvoIslandActor {
     * @param deletors  the functions to be used for deciding which solutions to delete.
     * @param fitnesses the objective functions to maximize.
     */
-  def from[Sol](creators: TraversableOnce[TCreatorFunc[Sol]],
-                mutators: TraversableOnce[TMutatorFunc[Sol]],
-                deletors: TraversableOnce[TDeletorFunc[Sol]],
-                fitnesses: TraversableOnce[TObjective[Sol]])
+  def from[Sol](creators: TraversableOnce[CreatorFunction[Sol]],
+                mutators: TraversableOnce[MutatorFunction[Sol]],
+                deletors: TraversableOnce[DeletorFunction[Sol]],
+                fitnesses: TraversableOnce[Objective[Sol]])
                (implicit system: ActorSystem)
-  : TEvolutionaryProcess[Sol] = {
+  : EvolutionaryProcess[Sol] = {
     // TODO validate that there is at least one of each creator/mutator/deletors/fitness
 
     val props = Props(new EvvoIslandActor[Sol](
@@ -91,19 +90,19 @@ object EvvoIslandActor {
     *
     * @param ref the reference to wrap
     */
-  case class Wrapper[Sol](ref: ActorRef) extends TEvolutionaryProcess[Sol] {
+  case class Wrapper[Sol](ref: ActorRef) extends EvolutionaryProcess[Sol] {
     implicit val timeout: Timeout = Timeout(5.days)
 
-    override def runBlocking(terminationCriteria: TTerminationCriteria): Unit = {
+    override def runBlocking(terminationCriteria: TerminationCriteria): Unit = {
       Await.result(this.runAsync(terminationCriteria), Duration.Inf)
     }
 
-    override def runAsync(terminationCriteria: TTerminationCriteria): Future[Unit] = {
+    override def runAsync(terminationCriteria: TerminationCriteria): Future[Unit] = {
       (ref ? Run(terminationCriteria)).asInstanceOf[Future[Unit]]
     }
 
-    override def currentParetoFrontier(): TParetoFrontier[Sol] = {
-      Await.result(ref ? GetParetoFrontier, Duration.Inf).asInstanceOf[TParetoFrontier[Sol]]
+    override def currentParetoFrontier(): ParetoFrontier[Sol] = {
+      Await.result(ref ? GetParetoFrontier, Duration.Inf).asInstanceOf[ParetoFrontier[Sol]]
     }
 
     override def emigrate(solutions: Seq[Sol]): Unit = {
@@ -115,7 +114,7 @@ object EvvoIslandActor {
     }
   }
 
-  case class Run(terminationCriteria: TTerminationCriteria)
+  case class Run(terminationCriteria: TerminationCriteria)
 
   case object GetParetoFrontier
 

--- a/src/main/scala/com/evvo/island/IslandManager.scala
+++ b/src/main/scala/com/evvo/island/IslandManager.scala
@@ -5,28 +5,25 @@ import java.io.File
 import akka.actor.{Actor, ActorSystem, Address, AddressFromURIString, Deploy, PoisonPill, Props}
 import akka.event.LoggingReceive
 import akka.remote.RemoteScope
+import akka.util.Timeout
 import com.evvo.island.EvvoIslandActor.{Emigrate, GetParetoFrontier, Run}
-import com.evvo.island.population.{ParetoFrontier, TParetoFrontier, TScored}
+import com.evvo.island.population.{ParetoFrontier, Scored}
 import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.Duration
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
-import collection.JavaConverters._
-import akka.pattern.ask
-import akka.util.Timeout
-
-import scala.concurrent.duration._
+import scala.concurrent.duration.{Duration, _}
+import scala.concurrent.{Await, Future}
 
 /**
-  * Launches and manages multiple EvvoIslands.
+  * Launches and manages multiple EvvoIslandActors.
   */
 class IslandManager[Sol](val numIslands: Int,
                          islandBuilder: EvvoIslandBuilder[Sol],
                          val actorSystemName: String = "EvvoNode",
                          val userConfig: String = "src/main/resources/application.conf")
                         (implicit system: ActorSystem)
-  extends TEvolutionaryProcess[Sol] with Actor {
+  extends EvolutionaryProcess[Sol] with Actor {
 
 
   private val configFile = ConfigFactory.parseFile(new File("src/main/resources/application.conf"))
@@ -45,7 +42,7 @@ class IslandManager[Sol](val numIslands: Int,
   /**
     * The final pareto frontier after the island shuts down, or None until then.
     */
-  private var finalParetoFrontier: Option[TParetoFrontier[Sol]] = None
+  private var finalParetoFrontier: Option[ParetoFrontier[Sol]] = None
 
   implicit val timeout: Timeout = 1.second
 
@@ -75,7 +72,7 @@ class IslandManager[Sol](val numIslands: Int,
   }
 
 
-  override def runAsync(terminationCriteria: TTerminationCriteria)
+  override def runAsync(terminationCriteria: TerminationCriteria)
   : Future[Unit] = {
     Future {
       val runIslands = this.islands.map(_.runAsync(terminationCriteria))
@@ -86,19 +83,19 @@ class IslandManager[Sol](val numIslands: Int,
     }
   }
 
-  def runBlocking(terminationCriteria: TTerminationCriteria): Unit = {
+  def runBlocking(terminationCriteria: TerminationCriteria): Unit = {
     // TODO replace Duration.Inf
     Await.result(this.runAsync(terminationCriteria), Duration.Inf)
   }
 
-  override def currentParetoFrontier(): TParetoFrontier[Sol] = {
+  override def currentParetoFrontier(): ParetoFrontier[Sol] = {
     finalParetoFrontier match {
       case Some(paretoFrontier) =>
         paretoFrontier
       case None =>
         val islandFrontiers = islands
           .map(_.currentParetoFrontier().solutions)
-          .foldLeft(Set[TScored[Sol]]())(_ | _)
+          .foldLeft(Set[Scored[Sol]]())(_ | _)
 
         ParetoFrontier(islandFrontiers)
     }
@@ -115,7 +112,7 @@ object IslandManager {
                 islandBuilder: EvvoIslandBuilder[Sol],
                 actorSystemName: String = "EvvoNode",
                 userConfig: String = "src/main/resources/application.conf")
-               (implicit system: ActorSystem): TEvolutionaryProcess[Sol] = {
+               (implicit system: ActorSystem): EvolutionaryProcess[Sol] = {
     EvvoIslandActor.Wrapper(
       system.actorOf(Props(
         new IslandManager[Sol](numIslands, islandBuilder, userConfig=userConfig))))

--- a/src/main/scala/com/evvo/island/LocalEvvoIsland.scala
+++ b/src/main/scala/com/evvo/island/LocalEvvoIsland.scala
@@ -1,8 +1,8 @@
 package com.evvo.island
 
 import akka.event.LoggingAdapter
-import com.evvo.agent.{TCreatorFunc, TDeletorFunc, TMutatorFunc}
-import com.evvo.island.population.{TObjective, TParetoFrontier}
+import com.evvo.agent.{CreatorFunction, DeletorFunction, MutatorFunction}
+import com.evvo.island.population.{Objective, ParetoFrontier}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
@@ -14,24 +14,24 @@ import scala.concurrent.Future
   */
 class LocalEvvoIsland[Sol]
 (
-  creators: Vector[TCreatorFunc[Sol]],
-  mutators: Vector[TMutatorFunc[Sol]],
-  deletors: Vector[TDeletorFunc[Sol]],
-  fitnesses: Vector[TObjective[Sol]]
+  creators: Vector[CreatorFunction[Sol]],
+  mutators: Vector[MutatorFunction[Sol]],
+  deletors: Vector[DeletorFunction[Sol]],
+  fitnesses: Vector[Objective[Sol]]
 )(
   implicit val log: LoggingAdapter = LocalLogger
-) extends TEvolutionaryProcess[Sol] {
+) extends EvolutionaryProcess[Sol] {
   private val island = new EvvoIsland(creators, mutators, deletors, fitnesses)
 
-  override def runBlocking(terminationCriteria: TTerminationCriteria): Unit = {
+  override def runBlocking(terminationCriteria: TerminationCriteria): Unit = {
     island.runBlocking(terminationCriteria)
   }
 
-  override def runAsync(terminationCriteria: TTerminationCriteria): Future[Unit] = {
+  override def runAsync(terminationCriteria: TerminationCriteria): Future[Unit] = {
     island.runAsync(terminationCriteria)
   }
 
-  override def currentParetoFrontier(): TParetoFrontier[Sol] = {
+  override def currentParetoFrontier(): ParetoFrontier[Sol] = {
     island.currentParetoFrontier()
   }
 

--- a/src/main/scala/com/evvo/island/island.scala
+++ b/src/main/scala/com/evvo/island/island.scala
@@ -1,28 +1,28 @@
 package com.evvo.island
 
-import com.evvo.island.population.TParetoFrontier
+import com.evvo.island.population.ParetoFrontier
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
 /**
-  * An evolutionary process with a set of actors that all act upon one set of solutions.
+  * `EvolutionaryProcess` is a generic interface for evolutionary problem solvers.
   */
-trait TEvolutionaryProcess[Solution] {
+trait EvolutionaryProcess[Solution] {
   /**
     * Run this island, until the specified termination criteria is met. This call will block
     * until the termination criteria is completed.
     *
     * @return this
     */
-  def runBlocking(terminationCriteria: TTerminationCriteria): Unit
+  def runBlocking(terminationCriteria: TerminationCriteria): Unit
 
-  def runAsync(terminationCriteria: TTerminationCriteria): Future[Unit]
+  def runAsync(terminationCriteria: TerminationCriteria): Future[Unit]
 
   /**
     * @return the current pareto frontier of solutions on this island?
     */
-  def currentParetoFrontier(): TParetoFrontier[Solution]
+  def currentParetoFrontier(): ParetoFrontier[Solution]
 
   /**
     * Provides a set of solutions to be added to the population of an EvolutionaryProcess.
@@ -38,13 +38,9 @@ trait TEvolutionaryProcess[Solution] {
 }
 
 /**
-  * Tells you how long to run an island for.
+  * Defines how long an evolutionary process should be run for.
+  *
+  * @param time Specifies a maximum duration to run, for example, `1.second` will stop running
+  *             the evolutionary process after one second.
   */
-trait TTerminationCriteria {
-  /**
-    * Stop after the specified duration has elapsed.
-    */
-  def time: Duration
-}
-
-case class TerminationCriteria(time: Duration) extends TTerminationCriteria
+case class TerminationCriteria(time: Duration)

--- a/src/main/scala/com/evvo/island/population/fitness.scala
+++ b/src/main/scala/com/evvo/island/population/fitness.scala
@@ -3,38 +3,18 @@ package com.evvo.island.population
 import com.evvo.ObjectiveFunctionType
 
 /**
-  * A real valued objective.
+  *
+  * @param objective             The underlying function: takes a `Sol` and scores it.
+  * @param name                  the name of this objective
+  * @param optimizationDirection oneof `Minimize` or `Maximize`
+  * @param precision             how many decimal points to round to. For example, if given 1,
+  *                              .015 and .018 will be considered equal.
   */
-trait TObjective[Sol] {
-
-  /**
-    * The score, to be minimized.
-    * param: the solution to score
-    * @return the score, according to this objective
-    */
-  def score:  ObjectiveFunctionType[Sol]
-
-  def name: String
-
-  /**
-    * @return How many significant figures to keep.
-    */
-  def precision: Int
-
-  /**
-    * @return the direction to optimize in - either Minimize or Maximize
-    */
-  def optimizationDirection: OptimizationDirection
-
-  override def toString: String = s"Objective[${this.name}]"
-}
-
 case class Objective[Sol](private val objective: ObjectiveFunctionType[Sol],
                           name: String,
                           optimizationDirection: OptimizationDirection,
-                          precision: Int = 3) // scalastyle:ignore magic.number
-  extends TObjective[Sol] {
-  override def score: ObjectiveFunctionType[Sol] = sol => {
+                          precision: Int = 3) { // scalastyle:ignore magic.number
+  def score: ObjectiveFunctionType[Sol] = sol => {
     val roundingMultiple = math.pow(10, precision) // scalastyle:ignore magic.number
     math.round(objective(sol) * roundingMultiple) / roundingMultiple
   }

--- a/src/main/scala/com/evvo/island/population/paretofrontier.scala
+++ b/src/main/scala/com/evvo/island/population/paretofrontier.scala
@@ -3,15 +3,9 @@ package com.evvo.island.population
 import scala.collection.mutable
 
 /**
-  * Represents a set of solutions that are non-dominated.
+  * A set of solutions, none of which dominate each other.
   */
-trait TParetoFrontier[Sol] {
-  //TODO replace with IndexedSeq and provide alternate hashing here
-  def solutions: Set[TScored[Sol]]
-}
-
-case class ParetoFrontier[Sol](solutions: Set[TScored[Sol]])
-  extends TParetoFrontier[Sol] {
+case class ParetoFrontier[Sol](solutions: Set[Scored[Sol]]) {
   if (!ParetoFrontier.isParetoFrontier(solutions)) {
     throw new IllegalArgumentException(
       s"""
@@ -30,16 +24,16 @@ case class ParetoFrontier[Sol](solutions: Set[TScored[Sol]])
 }
 
 object ParetoFrontier {
-  def apply[Sol](solutions: Set[TScored[Sol]]): ParetoFrontier[Sol] = {
+  def apply[Sol](solutions: Set[Scored[Sol]]): ParetoFrontier[Sol] = {
     new ParetoFrontier(setToParetoFrontier(solutions))
   }
 
   // TODO test this for performance, and optimize - this is likely to become a bottleneck
   // https://static.aminer.org/pdf/PDF/000/211/201/on_the_computational_complexity_of_finding_the_maxima_of_a.pdf
-  def setToParetoFrontier[Sol](solutions: Set[TScored[Sol]]): Set[TScored[Sol]] = {
+  def setToParetoFrontier[Sol](solutions: Set[Scored[Sol]]): Set[Scored[Sol]] = {
 
     // mutable set used here for performance, converted back to immutable afterwards
-    val out: mutable.Set[TScored[Sol]] = mutable.Set()
+    val out: mutable.Set[Scored[Sol]] = mutable.Set()
 
     for (sol <- solutions) {
       // if, for all other elements in the population..
@@ -65,9 +59,7 @@ object ParetoFrontier {
     out.toSet
   }
 
-  def isParetoFrontier[Sol](solutions: Set[TScored[Sol]]): Boolean = {
+  def isParetoFrontier[Sol](solutions: Set[Scored[Sol]]): Boolean = {
     solutions == ParetoFrontier.setToParetoFrontier(solutions)
   }
-
-
 }

--- a/src/main/scala/com/evvo/island/population/population.scala
+++ b/src/main/scala/com/evvo/island/population/population.scala
@@ -84,7 +84,6 @@ case class StandardPopulation[Sol](fitnessFunctionsIter: TraversableOnce[Objecti
 
   override def deleteSolutions(solutions: TraversableOnce[Scored[Sol]]): Unit = {
     population --= solutions
-
   }
 
   override def getParetoFrontier(): ParetoFrontier[Sol] = {

--- a/src/main/scala/com/evvo/island/population/population.scala
+++ b/src/main/scala/com/evvo/island/population/population.scala
@@ -1,17 +1,20 @@
 package com.evvo.island.population
 
 import akka.event.LoggingAdapter
-import com.evvo.agent.{PopulationInformation, TPopulationInformation}
+import com.evvo.agent.PopulationInformation
 
 import scala.collection.{TraversableOnce, mutable}
 
 
 /**
-  * A population is the set of all solutions current in an evolutionary process.
+  * A population is the set of all solutions current in an evolutionary process. Currently,
+  * the only extending class is StandardPopulation, but other classes may have different behavior,
+  * such as only ever keeping the non-dominated set, or only keeping points that are dominated
+  * by <=2 points, etc.
   *
   * @tparam Sol the type of the solutions in the population
   */
-trait TPopulation[Sol] {
+trait Population[Sol] {
   /**
     * Adds the given solutions, if they are unique, subject to any additional constraints
     * imposed on the solutions by the population.
@@ -29,45 +32,44 @@ trait TPopulation[Sol] {
     * @param n the number of unique solutions.
     * @return n unique solutions.
     */
-  def getSolutions(n: Int): IndexedSeq[TScored[Sol]]
+  def getSolutions(n: Int): IndexedSeq[Scored[Sol]]
 
   /**
     * Remove the given solutions from the population.
     *
     * @param solutions the solutions to remove
     */
-  def deleteSolutions(solutions: TraversableOnce[TScored[Sol]]): Unit
+  def deleteSolutions(solutions: TraversableOnce[Scored[Sol]]): Unit
 
   /**
     * @return the current pareto frontier of this population
     */
-  def getParetoFrontier(): TParetoFrontier[Sol]
+  def getParetoFrontier(): ParetoFrontier[Sol]
 
   /** @return a diagnostic report on this island, for agents to determine how often to run. */
-  def getInformation(): TPopulationInformation
+  def getInformation(): PopulationInformation
 }
 
+
 /**
-  * The actor that maintains the population.
+  * A population, as a set of scored solutions. Will contain no duplicates by score, unless
+  * hashing is `HashingStrategy.ON_SOLUTIONS`.
   *
   * @tparam Sol the type of the solutions in the population
   */
-case class Population[Sol](fitnessFunctionsIter: TraversableOnce[TObjective[Sol]],
-                           hashing: HashingStrategy.Value = HashingStrategy.ON_SCORES)
-                          (implicit val logger: LoggingAdapter)
-  extends TPopulation[Sol] {
+case class StandardPopulation[Sol](fitnessFunctionsIter: TraversableOnce[Objective[Sol]],
+                                   hashing: HashingStrategy.Value = HashingStrategy.ON_SCORES)
+                                  (implicit val logger: LoggingAdapter)
+  extends Population[Sol] {
   private val fitnessFunctions = fitnessFunctionsIter.toSet
-  private var population = mutable.Set[TScored[Sol]]()
-  private var populationVector = Vector[TScored[Sol]]()
-  private var getSolutionIndex = 0
-
+  private var population = mutable.Set[Scored[Sol]]()
 
   override def addSolutions(solutions: TraversableOnce[Sol]): Unit = {
     population ++= solutions.map(score)
     logger.debug(f"Added ${solutions.size} solutions, new population size ${population.size}")
   }
 
-  private def score(solution: Sol): TScored[Sol] = {
+  private def score(solution: Sol): Scored[Sol] = {
     val scores = fitnessFunctions.map(func => {
       (func.toString, func.optimizationDirection) -> func.score(solution)
     }).toMap
@@ -75,21 +77,21 @@ case class Population[Sol](fitnessFunctionsIter: TraversableOnce[TObjective[Sol]
   }
 
 
-  override def getSolutions(n: Int): Vector[TScored[Sol]] = {
+  override def getSolutions(n: Int): Vector[Scored[Sol]] = {
     // TODO: This can't be the final impl, inefficient space and time
-      util.Random.shuffle(population.toVector).take(n)
+    util.Random.shuffle(population.toVector).take(n)
   }
 
-  override def deleteSolutions(solutions: TraversableOnce[TScored[Sol]]): Unit = {
+  override def deleteSolutions(solutions: TraversableOnce[Scored[Sol]]): Unit = {
     population --= solutions
 
   }
 
-  override def getParetoFrontier(): TParetoFrontier[Sol] = {
+  override def getParetoFrontier(): ParetoFrontier[Sol] = {
     ParetoFrontier(this.population.toSet)
   }
 
-  override def getInformation(): TPopulationInformation = {
+  override def getInformation(): PopulationInformation = {
     val out = PopulationInformation(population.size)
     logger.debug(s"getInformation returning ${out}")
     out

--- a/src/main/scala/com/evvo/island/population/scored.scala
+++ b/src/main/scala/com/evvo/island/population/scored.scala
@@ -3,17 +3,16 @@ package com.evvo.island.population
 import com.evvo.island.population.HashingStrategy.HashingStrategy
 
 /**
-  * Represents a solution scored by mutliple fitness functions.
+  * A solution, which has been scored by mutliple fitness functions.
+  *
+  * @param score        Maps the name of fitness functions to the score of the solution with respect to them.
+  * @param solution     The solution that has been scored.
+  * @param hashStrategy How to hash this scored solution - on the score, or on the solution?
+  * @tparam Sol The type of the solution that has been scored.
   */
-trait TScored[Sol] {
-  /**
-    * Maps the name of fitness functions to the score of the solution with respect to them.
-    */
-  def score: Map[(String, OptimizationDirection), Double]
-
-  def solution: Sol
-
-  def hashStrategy: HashingStrategy.Value
+case class Scored[Sol](score: Map[(String, OptimizationDirection), Double],
+                       solution: Sol,
+                       hashStrategy: HashingStrategy = HashingStrategy.ON_SCORES) {
 
   override def hashCode(): Int = hashStrategy match {
     case HashingStrategy.ON_SCORES => this.score.hashCode()
@@ -21,7 +20,7 @@ trait TScored[Sol] {
   }
 
   override def equals(obj: Any): Boolean = obj match {
-    case that: TScored[Sol] =>
+    case that: Scored[Sol] =>
       hashStrategy match {
         case HashingStrategy.ON_SCORES => this.score.equals(that.score)
         case HashingStrategy.ON_SOLUTIONS => this.solution.equals(that.solution)
@@ -30,12 +29,8 @@ trait TScored[Sol] {
   }
 }
 
+
 object HashingStrategy extends Enumeration {
   type HashingStrategy = Value
   val ON_SOLUTIONS, ON_SCORES = Value
 }
-
-case class Scored[Sol](score: Map[(String, OptimizationDirection), Double],
-                       solution: Sol,
-                       hashStrategy: HashingStrategy = HashingStrategy.ON_SCORES)
-  extends TScored[Sol]

--- a/src/main/scala/com/evvo/package.scala
+++ b/src/main/scala/com/evvo/package.scala
@@ -1,11 +1,11 @@
 package com
 
-import com.evvo.island.population.TScored
+import com.evvo.island.population.Scored
 
 package object evvo {
   type CreatorFunctionType[Sol] = () => TraversableOnce[Sol]
-  type MutatorFunctionType[Sol] = IndexedSeq[TScored[Sol]] => TraversableOnce[Sol]
-  type DeletorFunctionType[Sol] = IndexedSeq[TScored[Sol]] => TraversableOnce[TScored[Sol]]
+  type MutatorFunctionType[Sol] = IndexedSeq[Scored[Sol]] => TraversableOnce[Sol]
+  type DeletorFunctionType[Sol] = IndexedSeq[Scored[Sol]] => TraversableOnce[Scored[Sol]]
 
   type ObjectiveFunctionType[Sol] = Sol => Double
 }

--- a/src/main/scala/com/evvo/remoting/Remoting.scala
+++ b/src/main/scala/com/evvo/remoting/Remoting.scala
@@ -3,12 +3,13 @@ package com.evvo.remoting
 import java.io.File
 
 import akka.actor.ActorSystem
-import com.evvo.agent.defaults.DeleteWorstHalfByRandomObjective
 import com.evvo.agent.{CreatorFunc, MutatorFunc}
+import com.evvo.agent.defaults.DeleteWorstHalfByRandomObjective
 import com.evvo.island.population.{Maximize, Objective}
 import com.evvo.island.{EvvoIslandActor, IslandManager, TerminationCriteria}
 import com.evvo.{CreatorFunctionType, MutatorFunctionType}
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.duration._
 
 object Remoting {

--- a/src/test/TODO.md
+++ b/src/test/TODO.md
@@ -1,2 +1,2 @@
-- we ought to have a better way to construct TScoreds, manually creating them is getting repetitive and error prone
+- we ought to have a better way to construct Scoreds, manually creating them is getting repetitive and error prone
 - we should have a more comprehensive benchmarking framework for testing performance regressions

--- a/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
+++ b/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
@@ -2,7 +2,7 @@ package com.evvo.integration
 
 import com.evvo.agent.TDeletorFunc
 import com.evvo.agent.defaults.DeleteWorstHalfByRandomObjective
-import com.evvo.island.{EvvoIslandBuilder, TEvolutionaryProcess, TerminationCriteria}
+import com.evvo.island.{EvvoIslandBuilder, EvolutionaryProcess, TerminationCriteria}
 import com.evvo.tags.{Performance, Slow}
 import com.evvo.{CreatorFunctionType, MutatorFunctionType, NullLogger, ObjectiveFunctionType}
 import org.scalatest.{Matchers, WordSpec}
@@ -38,7 +38,7 @@ class LocalEvvoTest extends WordSpec with Matchers {
     * @param listLength the length of the lists to sort.
     * @return
     */
-  def getEvvo(listLength: Int): TEvolutionaryProcess[Solution] = {
+  def getEvvo(listLength: Int): EvolutionaryProcess[Solution] = {
     val createFunc: CreatorFunctionType[Solution] = () => {
       Vector((listLength to 1 by -1).toList)
     }

--- a/src/test/unit/scala/com/evvo/ParetoFrontierTest.scala
+++ b/src/test/unit/scala/com/evvo/ParetoFrontierTest.scala
@@ -8,7 +8,7 @@ class ParetoFrontierTest extends WordSpec with Matchers {
     "Not include dominated solutions" in {
       val dominating = Scored[Int](Map(("a", Minimize) -> 0, ("b", Minimize) -> 0), 1)
       val losing = Scored[Int](Map(("a", Minimize) -> 99, ("b", Minimize) -> 99), 2)
-      val pop = Set[TScored[Int]](dominating, losing)
+      val pop = Set[Scored[Int]](dominating, losing)
       val pf = ParetoFrontier(pop).solutions
 
       pf should have size 1
@@ -19,7 +19,7 @@ class ParetoFrontierTest extends WordSpec with Matchers {
     "Not include solutions that tie on some solutions and lose on others" in {
       val dominating = Scored[Int](Map(("a", Minimize) -> 99, ("b", Minimize) -> 0), 1)
       val losing = Scored[Int](Map(("a", Minimize) -> 99, ("b", Minimize) -> 99), 2)
-      val pop = Set[TScored[Int]](dominating, losing)
+      val pop = Set[Scored[Int]](dominating, losing)
       val pf = ParetoFrontier(pop).solutions
 
       pf should have size 1
@@ -30,7 +30,7 @@ class ParetoFrontierTest extends WordSpec with Matchers {
     "Respect the direction objectives want to be optimized in" in {
       val lowMinSolution = Scored[Double](Map(("a", Minimize) -> 1d), 2)
       val highMinSolution =  Scored[Double](Map(("a", Minimize) -> 3d), 4)
-      val minPop = Set[TScored[Double]](lowMinSolution, highMinSolution)
+      val minPop = Set[Scored[Double]](lowMinSolution, highMinSolution)
       val minParetoFrontier = ParetoFrontier(minPop).solutions
 
       minParetoFrontier should contain(lowMinSolution)
@@ -39,7 +39,7 @@ class ParetoFrontierTest extends WordSpec with Matchers {
 
       val lowMaxSolution = Scored[Double](Map(("a", Maximize) -> 1d), 2)
       val highMaxSolution =  Scored[Double](Map(("a", Maximize) -> 3d), 4)
-      val maxPop = Set[TScored[Double]](lowMaxSolution, highMaxSolution)
+      val maxPop = Set[Scored[Double]](lowMaxSolution, highMaxSolution)
       val maxParetoFrontier = ParetoFrontier(maxPop).solutions
 
       maxParetoFrontier should not contain(lowMaxSolution)

--- a/src/test/unit/scala/com/evvo/agent/AgentPropertiesTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/AgentPropertiesTest.scala
@@ -2,7 +2,7 @@ package com.evvo.agent
 
 import akka.event.LoggingAdapter
 import com.evvo._
-import com.evvo.island.population.{Minimize, Objective, Population, Scored, TObjective, TScored}
+import com.evvo.island.population.{Minimize, Objective, Scored, StandardPopulation}
 import com.evvo.tags.Slow
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
 
@@ -17,7 +17,7 @@ class AgentPropertiesTest extends WordSpecLike with Matchers with BeforeAndAfter
 
   type S = Int
 
-  var pop: Population[S] = _
+  var pop: StandardPopulation[S] = _
 
   // a mapping from each function to whether it has been called yet
   var agentFunctionCalled: mutable.Map[Any, Boolean] = _
@@ -27,31 +27,31 @@ class AgentPropertiesTest extends WordSpecLike with Matchers with BeforeAndAfter
     Set(1)
   }
   val creatorFunc = CreatorFunc(create, "create")
-  var creatorAgent: TAgent[S] = _
+  var creatorAgent: Agent[S] = _
 
-  val mutate: MutatorFunctionType[S] = (seq: IndexedSeq[TScored[S]]) => {
+  val mutate: MutatorFunctionType[S] = (seq: IndexedSeq[Scored[S]]) => {
     agentFunctionCalled("mutate") = true
     seq.map(_.solution + 1)
   }
   val mutatorFunc = MutatorFunc(mutate, "mutate")
-  var mutatorAgent: TAgent[S] = _
-  val mutatorInput: Set[TScored[S]] = Set[TScored[S]](Scored(Map(("Score1", Minimize) -> 3), 2))
+  var mutatorAgent: Agent[S] = _
+  val mutatorInput: Set[Scored[S]] = Set[Scored[S]](Scored(Map(("Score1", Minimize) -> 3), 2))
 
   val delete: DeletorFunctionType[S] = set => {
     agentFunctionCalled("delete") = true
     set
   }
   val deletorFunc = DeletorFunc(delete, "delete", 1)
-  var deletorAgent: TAgent[S] = _
-  val deletorInput: Set[TScored[S]] = mutatorInput
+  var deletorAgent: Agent[S] = _
+  val deletorInput: Set[Scored[S]] = mutatorInput
 
-  var agents: Vector[TAgent[S]] = _
-  val strategy: TAgentStrategy = _ => 70.millis
+  var agents: Vector[Agent[S]] = _
+  val strategy: AgentStrategy = _ => 70.millis
 
-  val fitnessFunc: TObjective[S] = Objective(_.toDouble, "Double", Minimize)
+  val fitnessFunc: Objective[S] = Objective(_.toDouble, "Double", Minimize)
 
   before {
-    pop = Population[S](Vector(fitnessFunc))
+    pop = StandardPopulation[S](Vector(fitnessFunc))
     creatorAgent = CreatorAgent(creatorFunc, pop, strategy)
     mutatorAgent = MutatorAgent(mutatorFunc, pop, strategy)
     deletorAgent = DeletorAgent(deletorFunc, pop, strategy)

--- a/src/test/unit/scala/com/evvo/island/population/StandardPopulationTest.scala
+++ b/src/test/unit/scala/com/evvo/island/population/StandardPopulationTest.scala
@@ -6,7 +6,7 @@ import com.evvo.NullLogger
 import com.evvo.island.population
 import org.scalatest._
 
-class PopulationTest extends WordSpec with Matchers with BeforeAndAfter {
+class StandardPopulationTest extends WordSpec with Matchers with BeforeAndAfter {
   implicit val log: LoggingAdapter = NullLogger
 
   val identityFitness = population.Objective[Double](x => x, "Identity", Minimize)
@@ -14,7 +14,7 @@ class PopulationTest extends WordSpec with Matchers with BeforeAndAfter {
 
 
   "An empty population" should {
-    val emptyPop = Population(fitnesses)
+    val emptyPop = StandardPopulation(fitnesses)
 
     "not return any solutions" in {
       val sols = emptyPop.getSolutions(1)
@@ -29,7 +29,7 @@ class PopulationTest extends WordSpec with Matchers with BeforeAndAfter {
     }
 
     "become non-empty when added to" in {
-      val pop = Population(fitnesses)
+      val pop = StandardPopulation(fitnesses)
       pop.addSolutions(Set(1.0))
       val sols = pop.getSolutions(1)
       sols.length should not be 0
@@ -46,11 +46,11 @@ class PopulationTest extends WordSpec with Matchers with BeforeAndAfter {
     }
   }
 
-  var pop: Population[Double] = _
+  var pop: StandardPopulation[Double] = _
   val popSize = 10
   "A non-empty population hashing on solutions" should {
     before {
-      pop = population.Population(fitnesses, HashingStrategy.ON_SOLUTIONS)
+      pop = population.StandardPopulation(fitnesses, HashingStrategy.ON_SOLUTIONS)
       pop.addSolutions((1 to popSize).map(_.toDouble))
     }
 
@@ -70,7 +70,7 @@ class PopulationTest extends WordSpec with Matchers with BeforeAndAfter {
     }
 
     "return random subsections of the population" in {
-      val multipleSolSelections: List[Set[TScored[Double]]] =
+      val multipleSolSelections: List[Set[Scored[Double]]] =
         List.fill(12)(pop.getSolutions(popSize / 2).toSet)
       assert(multipleSolSelections.toSet.size > 1)
     }
@@ -103,14 +103,14 @@ class PopulationTest extends WordSpec with Matchers with BeforeAndAfter {
   "A population hashing on solutions" should {
 
     "not allow duplicate solutions" in {
-      val pop = population.Population(Vector(uniqueScore), HashingStrategy.ON_SOLUTIONS)
+      val pop = population.StandardPopulation(Vector(uniqueScore), HashingStrategy.ON_SOLUTIONS)
       pop.addSolutions(Vector(1, 1))
       val sol = pop.getSolutions(2)
       sol.length shouldBe 1
     }
 
     "allow duplicate scores for different solutions" in {
-      val pop = population.Population(Vector(returnOne), HashingStrategy.ON_SOLUTIONS)
+      val pop = population.StandardPopulation(Vector(returnOne), HashingStrategy.ON_SOLUTIONS)
       pop.addSolutions(Vector(1, 2))
       val sol = pop.getSolutions(2)
       sol.length shouldBe 2
@@ -120,14 +120,14 @@ class PopulationTest extends WordSpec with Matchers with BeforeAndAfter {
   "A population hashing on scores" should {
 
     "not allow duplicate scores" in {
-      val pop = population.Population(Vector(returnOne), HashingStrategy.ON_SCORES)
+      val pop = population.StandardPopulation(Vector(returnOne), HashingStrategy.ON_SCORES)
       pop.addSolutions(Vector(1, 2))
       val sol = pop.getSolutions(2)
       sol.length shouldBe 1
     }
 
     "allow duplicate solutions for different scores" in {
-      val pop = population.Population(Vector(uniqueScore), HashingStrategy.ON_SCORES)
+      val pop = population.StandardPopulation(Vector(uniqueScore), HashingStrategy.ON_SCORES)
       pop.addSolutions(Vector(1, 1))
       val sol = pop.getSolutions(2)
       sol.length shouldBe 2


### PR DESCRIPTION
Having traits named T… (like TPopulation) was weird. Now, we don't do that! We use case classes directly where there are unlikely to be multiple implementations, and traits with reasonable names in places that are likely to (or already do!) have multiple implementations. For example, Population and the Creator/Mutator/Deletor functions are traits, so that they are extensible with different parameters.

Closes #52 