### PR TITLE
Run tests once, and exactly once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ script:
   # And then actually run it
   - overcommit --install
   - overcommit --run
-  - mvn scalastyle:check
-  - mvn test
+  - mvn clean scalastyle:check package
 
 
 notifications:

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
                     <execution>
                         <goals>
                             <goal>compile</goal>
-<!--                            <goal>testCompile</goal>-->
+                            <goal>testCompile</goal>
                         </goals>
 
                         <configuration>
@@ -128,6 +128,16 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <!-- Disable surefire, use scalatest instead  -->
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
@@ -136,18 +146,10 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>TestSuiteReport.txt</filereports>
-                    <!--<tagsToExclude>com.evvo.tags.Slow</tagsToExclude>-->
                 </configuration>
                 <executions>
                     <execution>
                         <id>test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>alltests</id>
                         <goals>
                             <goal>test</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 
     <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
-        <testSourceDirectory>src/test/unit/scala</testSourceDirectory>
+        <testSourceDirectory>src/test</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
+++ b/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
@@ -86,7 +86,7 @@ class LocalEvvoTest extends WordSpec with Matchers {
   implicit val log = NullLogger
 
   "Local Evvo" should {
-    val timeout = 300
+    val timeout = 500
     f"be able to sort a list of length 10 within $timeout milliseconds" taggedAs(Performance, Slow) in {
       val listLength = 10
       val terminate = StopAfter(timeout.millis)


### PR DESCRIPTION
* Remove `alltests` execution causing duplicate run stage
* Speed up build by only invoking `mvn` once
* Add `testCompile` back so we actually compile the tests.

closes #66 