### PR TITLE
Tag issue templates, add questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: Documentation
 about: Requests for additional or improved documentation
 title: ''
-labels: ''
+labels: documentation
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: Ask a question
+title: ''
+labels: question
+assignees: ''
+
+---
+
+** What is the question? **
+Please include context about _why_ you want to know what you're asking about. If we have context, we can give a better explanation!

--- a/.github/ISSUE_TEMPLATE/refactor-request.md
+++ b/.github/ISSUE_TEMPLATE/refactor-request.md
@@ -2,7 +2,7 @@
 name: Refactor request
 about: Request a refactor of some code, making it easier to maintain
 title: ''
-labels: ''
+labels: refactor
 assignees: ''
 
 ---


### PR DESCRIPTION
Now, when you make an issue using the template, it is automatically tagged with the right tag (`feature`, etc)