### PR TITLE
Refactor MutatorAgent to ModifierAgent

### DIFF
--- a/.idea/runConfigurations/All_Tests.xml
+++ b/.idea/runConfigurations/All_Tests.xml
@@ -29,8 +29,12 @@
     <buffered bufClass="com.evvo.agent.DeletorAgentDefaultStrategyTest" />
     <buffered bufClass="com.evvo.agent.FunctionSerializabilityTest" />
     <buffered bufClass="com.evvo.agent.FunctionSerializabilityTest" />
-    <buffered bufClass="com.evvo.agent.MutatorAgentDefaultStrategyTest" />
-    <buffered bufClass="com.evvo.agent.MutatorAgentDefaultStrategyTest" />
+    <buffered bufClass="com.evvo.agent.ModifierAgentDefaultStrategyTest" />
+    <buffered bufClass="com.evvo.agent.ModifierAgentDefaultStrategyTest" />
+    <buffered bufClass="com.evvo.agent.ModifierFunctionTest" />
+    <buffered bufClass="com.evvo.agent.ModifierFunctionTest" />
+    <buffered bufClass="com.evvo.agent.MutatorFunctionTest" />
+    <buffered bufClass="com.evvo.agent.MutatorFunctionTest" />
     <buffered bufClass="com.evvo.integration.LocalEvvoTest" />
     <buffered bufClass="com.evvo.integration.LocalEvvoTest" />
     <buffered bufClass="com.evvo.integration.LocalIslandManagerTest" />

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If our [built-in](./src/main/scala/com/evvo/agent/defaults/defaults.scala) _Crea
 
 **Modifier Agent**: often shortened to "Modifier", a Modifier Agent retrieves some number of solutions from the _population_, calls a function on that set of solutions to produce new solutions based on the input, and adds those new solutions to the _population_.
 
-**' Agent**: A type of _ModifierAgent_ that applies a one-to-one mapping over a set of solutions, and adds all the results.
+**Mutator Agent**: A type of _ModifierAgent_ that applies a one-to-one mapping over a set of solutions, and adds all the results.
 
 **Crossover Agent**: A type of _ModifierAgent_ that applies a two-to-one function over a set of solutions, taking part of each input solution and combining them to produce new solutions.
 

--- a/src/main/scala/com/evvo/agent/agent.scala
+++ b/src/main/scala/com/evvo/agent/agent.scala
@@ -45,9 +45,7 @@ abstract class AAgent[Sol](private val strategy: AgentStrategy,
           }
           Thread.sleep(waitTime.toMillis)
 
-          // TODO oh god, this is arbitrary. Now that populations are running locally and this
-          // won't require a blocking Akka actor call, maybe we can recompute every time, or
-          // every second?
+          // this is arbitrary
           if (numInvocations % 33 == 0) {
             val nextInformation = population.getInformation()
             waitTime = strategy.waitTime(nextInformation)

--- a/src/main/scala/com/evvo/agent/defaults/defaults.scala
+++ b/src/main/scala/com/evvo/agent/defaults/defaults.scala
@@ -8,7 +8,7 @@
   */
 package com.evvo.agent.defaults
 
-import com.evvo.agent.{CreatorFunction, DeletorFunction, ModifierFunction}
+import com.evvo.agent.{CreatorFunction, DeletorFunction, MutatorFunction}
 import com.evvo.island.population
 import com.evvo.island.population.{Maximize, Minimize, Scored}
 
@@ -59,23 +59,15 @@ case class BitstringGenerator(length: Int, proportionOnes: Double = 0.5)
   }
 }
 
-/**
-  * A mutator that swaps two random bits.
-  *
-  * @param numInputs The number of solutions to request in the contents of each
-  *                  input set
-  */
-case class Bitswapper(override val numInputs: Int = 32)
-  extends ModifierFunction[Bitstring]("Bitswapper") {
-  override def modify(sols: IndexedSeq[Scored[Bitstring]]): TraversableOnce[Bitstring] = {
-    sols.map(s => {
-      val bitstring = s.solution
-      val index1 = util.Random.nextInt(bitstring.length)
-      val index2 = util.Random.nextInt(bitstring.length)
+/** A mutator for `Bitstring`s that swaps two random bits in a solution. */
+case class Bitswapper()
+  extends MutatorFunction[Bitstring]("Bitswapper") {
+  override def mutate(bitstring: Bitstring): Bitstring = {
+    val index1 = util.Random.nextInt(bitstring.length)
+    val index2 = util.Random.nextInt(bitstring.length)
 
-      // not mutation, doesn't need an intermediate temp variable
-      bitstring.updated(index1, bitstring(index2)).updated(index2, bitstring(index1))
-    })
+    // not mutation, doesn't need an intermediate temp variable
+    bitstring.updated(index1, bitstring(index2)).updated(index2, bitstring(index1))
   }
 }
 
@@ -86,12 +78,9 @@ case class Bitswapper(override val numInputs: Int = 32)
   *                  input set
   */
 case class Bitflipper(override val numInputs: Int = 32)
-  extends ModifierFunction[Bitstring]("Bitflipper") {
-  override def modify(sols: IndexedSeq[Scored[Bitstring]]): TraversableOnce[Bitstring] = {
-    sols.map(s => {
-      val bitstring = s.solution
-      val index1 = util.Random.nextInt(bitstring.length)
-      bitstring.updated(index1, !bitstring(index1))
-    })
+  extends MutatorFunction[Bitstring]("Bitflipper") {
+  override def mutate(bitstring: Bitstring): Bitstring = {
+    val index = util.Random.nextInt(bitstring.length)
+    bitstring.updated(index, !bitstring(index))
   }
 }

--- a/src/main/scala/com/evvo/agent/defaults/defaults.scala
+++ b/src/main/scala/com/evvo/agent/defaults/defaults.scala
@@ -8,7 +8,7 @@
   */
 package com.evvo.agent.defaults
 
-import com.evvo.agent.{CreatorFunction, DeletorFunction, MutatorFunction}
+import com.evvo.agent.{CreatorFunction, DeletorFunction, ModifierFunction}
 import com.evvo.island.population
 import com.evvo.island.population.{Maximize, Minimize, Scored}
 
@@ -66,8 +66,8 @@ case class BitstringGenerator(length: Int, proportionOnes: Double = 0.5)
   *                  input set
   */
 case class Bitswapper(override val numInputs: Int = 32)
-  extends MutatorFunction[Bitstring]("Bitswapper") {
-  override def mutate(sols: IndexedSeq[Scored[Bitstring]]): TraversableOnce[Bitstring] = {
+  extends ModifierFunction[Bitstring]("Bitswapper") {
+  override def modify(sols: IndexedSeq[Scored[Bitstring]]): TraversableOnce[Bitstring] = {
     sols.map(s => {
       val bitstring = s.solution
       val index1 = util.Random.nextInt(bitstring.length)
@@ -86,8 +86,8 @@ case class Bitswapper(override val numInputs: Int = 32)
   *                  input set
   */
 case class Bitflipper(override val numInputs: Int = 32)
-  extends MutatorFunction[Bitstring]("Bitflipper") {
-  override def mutate(sols: IndexedSeq[Scored[Bitstring]]): TraversableOnce[Bitstring] = {
+  extends ModifierFunction[Bitstring]("Bitflipper") {
+  override def modify(sols: IndexedSeq[Scored[Bitstring]]): TraversableOnce[Bitstring] = {
     sols.map(s => {
       val bitstring = s.solution
       val index1 = util.Random.nextInt(bitstring.length)

--- a/src/main/scala/com/evvo/agent/func.scala
+++ b/src/main/scala/com/evvo/agent/func.scala
@@ -23,7 +23,7 @@ abstract class CreatorFunction[Sol](name: String) extends NamedFunction(name) {
 }
 
 /**
-  * A function that produces a new set of solutions based on a set of solutions.
+  * A function that derives a new set of solutions from some input set of solutions.
   *
   * @param name                      This function's name
   * @param numInputs                 The number of solutions to request in the contents of each
@@ -31,15 +31,74 @@ abstract class CreatorFunction[Sol](name: String) extends NamedFunction(name) {
   * @param shouldRunWithPartialInput Whether this function should run if the number of solutions
   *                                  in the input is less than `numInputs`
   */
-abstract class MutatorFunction[Sol](name: String,
-                                    val numInputs: Int = 32,
-                                    val shouldRunWithPartialInput: Boolean = true)
+abstract class ModifierFunction[Sol](name: String,
+                                     val numInputs: Int = 32,
+                                     val shouldRunWithPartialInput: Boolean = true)
   extends NamedFunction(name) {
   /**
     * @return The function to call to produce new solutions
     */
-  def mutate(sols: IndexedSeq[Scored[Sol]]): TraversableOnce[Sol]
+  def modify(sols: IndexedSeq[Scored[Sol]]): TraversableOnce[Sol]
 }
+
+/**
+  * A function that uses a one-to-one mapping to derive a new set of solutions from some
+  * input set of solutions.
+  */
+abstract class MutatorFunction[Sol](name: String,
+                                    numInputs: Int = 32)
+  extends ModifierFunction[Sol](name, numInputs, shouldRunWithPartialInput = true) {
+  // Pass shouldRunWithPartialInput as true always - we know there is no requirement for more
+  // than 1 solution at a time, so safe to run on any number of solutions.
+
+  override final def modify(sols: IndexedSeq[Scored[Sol]]): TraversableOnce[Sol] = {
+    // We can define modify in terms of mutation, and ask implementors to just provide a one-to-one
+    // mutator function to map over the solutions.
+    sols.map(_.solution).map(mutate)
+  }
+
+  /**
+    * The method to apply to create new solutions.
+    *
+    * @param sol The solution to base the new solution on.
+    * @return The new solution, to be added to the population.
+    */
+  protected def mutate(sol: Sol): Sol
+}
+
+/**
+  * A function that uses a one-to-one mapping to derive a new set of solutions from some
+  * input set of solutions.
+  */
+abstract class CrossoverFunction[Sol](name: String,
+                                      numInputs: Int = 32)
+  extends ModifierFunction[Sol](name, numInputs, shouldRunWithPartialInput = true) {
+  // Pass shouldRunWithPartialInput as true always - we know there is no requirement for more
+  // than 2 solutions at a time, so safe to run on, say, 16 or 23 solutions. We will have to be
+  // careful about odd numbers of solutions.
+
+  override final def modify(sols: IndexedSeq[Scored[Sol]]): TraversableOnce[Sol] = {
+    // We can define modify in terms of crossover, and ask implementors to just provide a two-to-one
+    // crossover function to map over the solutions.
+    val groups = sols.map(_.solution).grouped(2)
+
+    // Use `collect` and partial functions to ensure that if there is an odd number of solutions,
+    // we never hit a runtime error, like we would with indexing into each group.
+    groups.collect {
+      case IndexedSeq(sol1, sol2) => crossover(sol1, sol2)
+    }
+  }
+
+  /**
+    * Combines two solutions to produce a new one.
+    *
+    * @param sol1 The first solution. Order is random, and has no meaning.
+    * @param sol2 The second solution. Order is random, and has no meaning.[
+    * @return The new solution, to be added to the population.
+    */
+  protected def crossover(sol1: Sol, sol2: Sol): Sol
+}
+
 
 /**
   * A function that, given a subset of a population, determines which solutions in that subset
@@ -54,7 +113,7 @@ abstract class MutatorFunction[Sol](name: String,
 abstract class DeletorFunction[Sol](name: String,
                                     val numInputs: Int = 32,
                                     val shouldRunWithPartialInput: Boolean = true)
-  extends NamedFunction(name)  {
+  extends NamedFunction(name) {
   /** @return The function to call to identify which solutions to delete */
   def delete(sols: IndexedSeq[Scored[Sol]]): TraversableOnce[Scored[Sol]]
 }

--- a/src/main/scala/com/evvo/agent/func.scala
+++ b/src/main/scala/com/evvo/agent/func.scala
@@ -92,8 +92,8 @@ abstract class CrossoverFunction[Sol](name: String,
   /**
     * Combines two solutions to produce a new one.
     *
-    * @param sol1 The first solution. Order is random, and has no meaning.
-    * @param sol2 The second solution. Order is random, and has no meaning.[
+    * @param sol1 One solution. Order is random, and has no meaning.
+    * @param sol2 Another solution. Order is random, and has no meaning.
     * @return The new solution, to be added to the population.
     */
   protected def crossover(sol1: Sol, sol2: Sol): Sol

--- a/src/main/scala/com/evvo/agent/modifier.scala
+++ b/src/main/scala/com/evvo/agent/modifier.scala
@@ -6,20 +6,20 @@ import com.evvo.island.population.Population
 import scala.concurrent.duration._
 
 
-case class ModifierAgent[Sol](mutate: ModifierFunction[Sol],
+case class ModifierAgent[Sol](modifier: ModifierFunction[Sol],
                               population: Population[Sol],
                               strategy: AgentStrategy = ModifierAgentDefaultStrategy())
                              (implicit val logger: LoggingAdapter)
-  extends AAgent[Sol](strategy, population, mutate.name)(logger) {
+  extends AAgent[Sol](strategy, population, modifier.name)(logger) {
 
   override protected def step(): Unit = {
-    val in = population.getSolutions(mutate.numInputs)
-    if (mutate.shouldRunWithPartialInput || in.length == mutate.numInputs) {
-      val mutatedSolutions = mutate.modify(in)
-      population.addSolutions(mutatedSolutions)
+    val in = population.getSolutions(modifier.numInputs)
+    if (modifier.shouldRunWithPartialInput || in.length == modifier.numInputs) {
+      val newSolutions = modifier.modify(in)
+      population.addSolutions(newSolutions)
     } else {
       logger.debug(s"${this}: not enough solutions in population: " +
-        s"got ${in.length}, wanted ${mutate.numInputs}")
+        s"got ${in.length}, wanted ${modifier.numInputs}")
     }
   }
 

--- a/src/main/scala/com/evvo/agent/modifier.scala
+++ b/src/main/scala/com/evvo/agent/modifier.scala
@@ -6,16 +6,16 @@ import com.evvo.island.population.Population
 import scala.concurrent.duration._
 
 
-case class MutatorAgent[Sol](mutate: MutatorFunction[Sol],
-                             population: Population[Sol],
-                             strategy: AgentStrategy = MutatorAgentDefaultStrategy())
-                            (implicit val logger: LoggingAdapter)
+case class ModifierAgent[Sol](mutate: ModifierFunction[Sol],
+                              population: Population[Sol],
+                              strategy: AgentStrategy = ModifierAgentDefaultStrategy())
+                             (implicit val logger: LoggingAdapter)
   extends AAgent[Sol](strategy, population, mutate.name)(logger) {
 
   override protected def step(): Unit = {
     val in = population.getSolutions(mutate.numInputs)
     if (mutate.shouldRunWithPartialInput || in.length == mutate.numInputs) {
-      val mutatedSolutions = mutate.mutate(in)
+      val mutatedSolutions = mutate.modify(in)
       population.addSolutions(mutatedSolutions)
     } else {
       logger.debug(s"${this}: not enough solutions in population: " +
@@ -26,7 +26,7 @@ case class MutatorAgent[Sol](mutate: MutatorFunction[Sol],
   override def toString: String = s"MutatorAgent[$name, $numInvocations]"
 }
 
-case class MutatorAgentDefaultStrategy() extends AgentStrategy {
+case class ModifierAgentDefaultStrategy() extends AgentStrategy {
   override def waitTime(populationInformation: PopulationInformation): Duration = {
     0.millis
   }

--- a/src/main/scala/com/evvo/agent/mutator.scala
+++ b/src/main/scala/com/evvo/agent/mutator.scala
@@ -27,7 +27,6 @@ case class MutatorAgent[Sol](mutate: MutatorFunction[Sol],
 }
 
 case class MutatorAgentDefaultStrategy() extends AgentStrategy {
-  // TODO this is bad. fix it.
   override def waitTime(populationInformation: PopulationInformation): Duration = {
     0.millis
   }

--- a/src/main/scala/com/evvo/agent/strategy.scala
+++ b/src/main/scala/com/evvo/agent/strategy.scala
@@ -8,7 +8,6 @@ import scala.concurrent.duration._
   * agent's task.
   */
 trait AgentStrategy {
-  // TODO returning a duration is arbitrary, find a better calling API/return type
   def waitTime(populationInformation: PopulationInformation): Duration
 }
 

--- a/src/main/scala/com/evvo/island/EvvoIsland.scala
+++ b/src/main/scala/com/evvo/island/EvvoIsland.scala
@@ -51,12 +51,10 @@ class EvvoIsland[Sol]
     Future {
       log.info(s"Island running with stopAfter=${stopAfter}")
 
-      // TODO can we put all of these in some combined pool? don't like having to manage each
       creatorAgents.foreach(_.start())
       mutatorAgents.foreach(_.start())
       deletorAgents.foreach(_.start())
 
-      // TODO this is not ideal. fix wait time/add features to termination criteria
       val startTime = Calendar.getInstance().toInstant.toEpochMilli
 
       while (startTime + stopAfter.time.toMillis >

--- a/src/main/scala/com/evvo/island/RemoteIslandManager.scala
+++ b/src/main/scala/com/evvo/island/RemoteIslandManager.scala
@@ -111,7 +111,6 @@ class RemoteIslandManager[Sol](val numIslands: Int,
   }
 
   def runBlocking(stopAfter: StopAfter): Unit = {
-    // TODO replace Duration.Inf
     this.islandManager.runBlocking(stopAfter)
   }
 
@@ -153,7 +152,6 @@ class LocalIslandManager[Sol](val numIslands: Int,
   }
 
   def runBlocking(stopAfter: StopAfter): Unit = {
-    // TODO replace Duration.Inf
     this.islandManager.runBlocking(stopAfter)
   }
 

--- a/src/main/scala/com/evvo/island/population/population.scala
+++ b/src/main/scala/com/evvo/island/population/population.scala
@@ -80,7 +80,6 @@ case class StandardPopulation[Sol](objectivesIter: TraversableOnce[Objective[Sol
 
 
   override def getSolutions(n: Int): Vector[Scored[Sol]] = {
-    // TODO: This can't be the final impl, inefficient space and time
     util.Random.shuffle(population.toVector).take(n)
   }
 

--- a/src/main/scala/com/evvo/professormatching/ProfessorMatching.scala
+++ b/src/main/scala/com/evvo/professormatching/ProfessorMatching.scala
@@ -98,8 +98,8 @@ object ProfessorMatching {
       .addObjective(new NumPrepsPreferences(idToProf, idToSection, idToSchedule))
       .addObjective(new ScheduleObjective(idToProf, idToSection, idToSchedule))
       .addCreator(new RandomScheduleCreator(idToProf, idToSection))
-      .addMutator(new SwapTwoCourses(idToProf))
-      .addMutator(new BalanceCourseload(idToProf))
+      .addModifier(new SwapTwoCourses(idToProf))
+      .addModifier(new BalanceCourseload(idToProf))
 
     val config = ConfigFactory
       .parseFile(new File("src/main/resources/application.conf"))
@@ -202,8 +202,8 @@ object ProfessorMatching {
 
   // =================================== MUTATOR ===================================================
   class SwapTwoCourses(idToProf: Map[ProfID, ProfPreferences])
-    extends MutatorFunction[PMSolution]("SwapTwo") {
-    override def mutate(sols: IndexedSeq[Scored[PMSolution]]): TraversableOnce[PMSolution] = {
+    extends ModifierFunction[PMSolution]("SwapTwo") {
+    override def modify(sols: IndexedSeq[Scored[PMSolution]]): TraversableOnce[PMSolution] = {
 
       def swap(sol: PMSolution): PMSolution = {
         val prof1: ProfPreferences = idToProf(randomKey(idToProf))
@@ -238,8 +238,8 @@ object ProfessorMatching {
   }
 
   class BalanceCourseload(idToProf: Map[ProfID, ProfPreferences])
-    extends MutatorFunction[PMSolution]("Balance") {
-    override def mutate(sols: IndexedSeq[Scored[PMSolution]]): TraversableOnce[PMSolution] = {
+    extends ModifierFunction[PMSolution]("Balance") {
+    override def modify(sols: IndexedSeq[Scored[PMSolution]]): TraversableOnce[PMSolution] = {
       def swap(sol: PMSolution): PMSolution = {
         val prof1: ProfPreferences = idToProf(randomKey(idToProf))
         val prof2: ProfPreferences = {

--- a/src/main/scala/com/evvo/professormatching/data.scala
+++ b/src/main/scala/com/evvo/professormatching/data.scala
@@ -14,9 +14,8 @@ case class ParsedProblem(professors: Vector[ParsedProfPreferences], sections: Ve
 
 }
 
-// TODO how to link to another class in ScalaDoc?
 /**
-  * See ProfPreferences.
+  * See [[io.evvo.professormatching.ProfPreferences]].
   */
 case class ParsedProfPreferences(id: Int,
                                  sectionScheduleToPreference: Map[String, Int],

--- a/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
+++ b/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
@@ -2,9 +2,9 @@ package com.evvo.integration
 
 import com.evvo.NullLogger
 import com.evvo.agent.defaults.DeleteWorstHalfByRandomObjective
-import com.evvo.agent.{CreatorFunction, ModifierFunction}
-import com.evvo.integration.LocalEvvoTestFixtures.{Creator, Modifier, NumInversions, Solution}
-import com.evvo.island.population.{Minimize, Objective, Scored}
+import com.evvo.agent.{CreatorFunction, MutatorFunction}
+import com.evvo.integration.LocalEvvoTestFixtures.{Creator, Mutator, NumInversions, Solution}
+import com.evvo.island.population.{Minimize, Objective}
 import com.evvo.island.{EvolutionaryProcess, EvvoIslandBuilder, StopAfter}
 import com.evvo.tags.{Performance, Slow}
 import org.scalatest.{Matchers, WordSpec}
@@ -30,7 +30,7 @@ class LocalEvvoTest extends WordSpec with Matchers {
 
     val islandBuilder = EvvoIslandBuilder[Solution]()
       .addCreator(new Creator(listLength))
-      .addModifier(new Modifier())
+      .addModifier(new Mutator())
       .addDeletor(DeleteWorstHalfByRandomObjective())
       .addObjective(new NumInversions())
 
@@ -67,20 +67,12 @@ object LocalEvvoTestFixtures {
     }
   }
 
-  class Modifier extends ModifierFunction[Solution]("Modifier") {
-    private def mutateOneSolution(sol: Solution): Solution = {
+  class Mutator extends MutatorFunction[Solution]("Modifier") {
+    override def mutate(sol: Solution): Solution = {
       val i = util.Random.nextInt(sol.length)
       val j = util.Random.nextInt(sol.length)
       val tmp = sol(j)
       sol.updated(j, sol(i)).updated(i, tmp)
-    }
-
-    override def modify(s: IndexedSeq[Scored[Solution]]): TraversableOnce[Solution] = {
-      s.map(scoredSol => {
-        val sol = scoredSol.solution
-        val out = mutateOneSolution(sol)
-        out
-      })
     }
   }
 

--- a/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
+++ b/src/test/integration/scala/com/evvo/integration/LocalEvvoTest.scala
@@ -28,17 +28,9 @@ class LocalEvvoTest extends WordSpec with Matchers {
     */
   def getEvvo(listLength: Int): EvolutionaryProcess[Solution] = {
 
-    // TODO add convenience constructor for adding multiple duplicate mutators/creators/deletors
     val islandBuilder = EvvoIslandBuilder[Solution]()
       .addCreator(new Creator(listLength))
       .addMutator(new Mutator())
-      .addMutator(new Mutator())
-      .addMutator(new Mutator())
-      .addMutator(new Mutator())
-      .addDeletor(DeleteWorstHalfByRandomObjective())
-      .addDeletor(DeleteWorstHalfByRandomObjective())
-      .addDeletor(DeleteWorstHalfByRandomObjective())
-      .addDeletor(DeleteWorstHalfByRandomObjective())
       .addDeletor(DeleteWorstHalfByRandomObjective())
       .addObjective(new NumInversions())
 

--- a/src/test/integration/scala/com/evvo/integration/LocalIslandManagerTest.scala
+++ b/src/test/integration/scala/com/evvo/integration/LocalIslandManagerTest.scala
@@ -1,8 +1,8 @@
 package com.evvo.integration
 
 import com.evvo.agent.defaults.DeleteDominated
-import com.evvo.agent.{CreatorFunction, ModifierFunction}
-import com.evvo.island.population.{Maximize, Objective, Scored}
+import com.evvo.agent.{CreatorFunction, MutatorFunction}
+import com.evvo.island.population.{Maximize, Objective}
 import com.evvo.island.{EvvoIslandBuilder, LocalIslandManager, StopAfter}
 import org.scalatest.{Matchers, WordSpec}
 
@@ -31,12 +31,10 @@ class LocalIslandManagerTest extends WordSpec with Matchers {
         override def create(): TraversableOnce[Solution] = Vector("evvo")
       }
 
-      val mutator = new ModifierFunction[Solution]("mutate") {
-        override def modify(sols: IndexedSeq[Scored[Solution]]): TraversableOnce[Solution] = {
-          sols.map(s => {
-            val (e, rest) = s.solution.splitAt(1)
-            e + util.Random.alphanumeric.head.toString + rest
-          })
+      val mutator = new MutatorFunction[Solution]("mutate") {
+        override def mutate(sol: Solution): Solution = {
+          val (e, rest) = sol.splitAt(1)
+          e + util.Random.alphanumeric.head.toString + rest
         }
       }
 

--- a/src/test/integration/scala/com/evvo/integration/LocalIslandManagerTest.scala
+++ b/src/test/integration/scala/com/evvo/integration/LocalIslandManagerTest.scala
@@ -1,7 +1,7 @@
 package com.evvo.integration
 
 import com.evvo.agent.defaults.DeleteDominated
-import com.evvo.agent.{CreatorFunction, MutatorFunction}
+import com.evvo.agent.{CreatorFunction, ModifierFunction}
 import com.evvo.island.population.{Maximize, Objective, Scored}
 import com.evvo.island.{EvvoIslandBuilder, LocalIslandManager, StopAfter}
 import org.scalatest.{Matchers, WordSpec}
@@ -31,8 +31,8 @@ class LocalIslandManagerTest extends WordSpec with Matchers {
         override def create(): TraversableOnce[Solution] = Vector("evvo")
       }
 
-      val mutator = new MutatorFunction[Solution]("mutate") {
-        override def mutate(sols: IndexedSeq[Scored[Solution]]): TraversableOnce[Solution] = {
+      val mutator = new ModifierFunction[Solution]("mutate") {
+        override def modify(sols: IndexedSeq[Scored[Solution]]): TraversableOnce[Solution] = {
           sols.map(s => {
             val (e, rest) = s.solution.splitAt(1)
             e + util.Random.alphanumeric.head.toString + rest
@@ -44,7 +44,7 @@ class LocalIslandManagerTest extends WordSpec with Matchers {
         .addObjective(startV)
         .addObjective(endV)
         .addCreator(creator)
-        .addMutator(mutator)
+        .addModifier(mutator)
         .addDeletor(DeleteDominated[Solution]())
 
       val manager = new LocalIslandManager(7, builder)

--- a/src/test/unit/scala/com/evvo/agent/AgentPropertiesTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/AgentPropertiesTest.scala
@@ -31,8 +31,8 @@ class AgentPropertiesTest extends WordSpecLike with Matchers with BeforeAndAfter
 
   var creatorAgent: Agent[S] = _
 
-  val mutatorFunc = new MutatorFunction[S]("mutator") {
-    def mutate(seq: IndexedSeq[Scored[S]]): IndexedSeq[S] = {
+  val mutatorFunc = new ModifierFunction[S]("mutator") {
+    def modify(seq: IndexedSeq[Scored[S]]): IndexedSeq[S] = {
       agentFunctionCalled("mutate") = true
       seq.map(_.solution + 1)
     }
@@ -61,7 +61,7 @@ class AgentPropertiesTest extends WordSpecLike with Matchers with BeforeAndAfter
   before {
     pop = StandardPopulation[S](Vector(fitnessFunc))
     creatorAgent = CreatorAgent(creatorFunc, pop, strategy)
-    mutatorAgent = MutatorAgent(mutatorFunc, pop, strategy)
+    mutatorAgent = ModifierAgent(mutatorFunc, pop, strategy)
     deletorAgent = DeletorAgent(deletorFunc, pop, strategy)
     agents = Vector(creatorAgent, mutatorAgent, deletorAgent)
 

--- a/src/test/unit/scala/com/evvo/agent/AgentPropertiesTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/AgentPropertiesTest.scala
@@ -31,15 +31,15 @@ class AgentPropertiesTest extends WordSpecLike with Matchers with BeforeAndAfter
 
   var creatorAgent: Agent[S] = _
 
-  val mutatorFunc = new ModifierFunction[S]("mutator") {
+  val mutatorFunc = new ModifierFunction[S]("modifier") {
     def modify(seq: IndexedSeq[Scored[S]]): IndexedSeq[S] = {
-      agentFunctionCalled("mutate") = true
+      agentFunctionCalled("modify") = true
       seq.map(_.solution + 1)
     }
   }
 
-  var mutatorAgent: Agent[S] = _
-  val mutatorInput: Set[Scored[S]] = Set[Scored[S]](Scored(Map(("Score1", Minimize) -> 3), 2))
+  var modifierAgent: Agent[S] = _
+  val modifierInput: Set[Scored[S]] = Set[Scored[S]](Scored(Map(("Score1", Minimize) -> 3), 2))
 
   val deletorFunc = new DeletorFunction[S]("deletor") {
     override def delete(sols: IndexedSeq[Scored[S]]): TraversableOnce[Scored[S]] = {
@@ -49,7 +49,7 @@ class AgentPropertiesTest extends WordSpecLike with Matchers with BeforeAndAfter
   }
 
   var deletorAgent: Agent[S] = _
-  val deletorInput: Set[Scored[S]] = mutatorInput
+  val deletorInput: Set[Scored[S]] = modifierInput
 
   var agents: Vector[Agent[S]] = _
   val strategy: AgentStrategy = _ => 70.millis
@@ -61,13 +61,13 @@ class AgentPropertiesTest extends WordSpecLike with Matchers with BeforeAndAfter
   before {
     pop = StandardPopulation[S](Vector(fitnessFunc))
     creatorAgent = CreatorAgent(creatorFunc, pop, strategy)
-    mutatorAgent = ModifierAgent(mutatorFunc, pop, strategy)
+    modifierAgent = ModifierAgent(mutatorFunc, pop, strategy)
     deletorAgent = DeletorAgent(deletorFunc, pop, strategy)
-    agents = Vector(creatorAgent, mutatorAgent, deletorAgent)
+    agents = Vector(creatorAgent, modifierAgent, deletorAgent)
 
     agentFunctionCalled = mutable.Map(
       "create" -> false,
-      "mutate" -> false,
+      "modify" -> false,
       "delete" -> false)
   }
 

--- a/src/test/unit/scala/com/evvo/agent/CrossoverFunctionTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/CrossoverFunctionTest.scala
@@ -1,0 +1,25 @@
+package com.evvo.agent
+
+import com.evvo.island.population.Scored
+import org.scalatest.{Matchers, WordSpec}
+
+class CrossoverFunctionTest extends WordSpec with Matchers {
+  "CrossoverFunction" should {
+    val crossoverFunction = new CrossoverFunction[Double]("+") {
+      override protected def crossover(sol1: Double, sol2: Double): Double = {
+        sol1 + sol2
+      }
+    }
+
+    "work on odd numbers of solutions" in {
+      crossoverFunction.modify(Vector(Scored(Map(), 0d)))
+    }
+
+    "apply the function to pairs" in {
+      val results = crossoverFunction.modify(
+        Vector(Scored(Map(), 1d), Scored(Map(), 3d)))
+
+      results.toVector should be(Vector(4d))
+    }
+  }
+}

--- a/src/test/unit/scala/com/evvo/agent/FunctionSerializabilityTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/FunctionSerializabilityTest.scala
@@ -6,6 +6,8 @@ import com.evvo.agent.defaults.DeleteWorstHalfByRandomObjective
 import com.evvo.island.population.Scored
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.collection.TraversableOnce
+
 /**
   * Creator, Mutator, and Deletor Functions all have to be serializable for akka actor
   * deployment to work.
@@ -36,8 +38,8 @@ class FunctionSerializabilityTest extends WordSpec with Matchers {
         override def create(): TraversableOnce[Double] = Vector(3)
       }
 
-      val m = new MutatorFunction[Double]("m") {
-        override def mutate(sols: IndexedSeq[Scored[Double]]): TraversableOnce[Double] = {
+      val m = new ModifierFunction[Double]("m") {
+        override def modify(sols: IndexedSeq[Scored[Double]]): TraversableOnce[Double] = {
           Vector(sols.head.solution)
         }
       }
@@ -58,8 +60,8 @@ class FunctionSerializabilityTest extends WordSpec with Matchers {
         override def create(): TraversableOnce[Double] = Vector(3)
       }
 
-      class M extends MutatorFunction[Double]("d") {
-        override def mutate(sols: IndexedSeq[Scored[Double]]): TraversableOnce[Double] = {
+      class M extends ModifierFunction[Double]("d") {
+        override def modify(sols: IndexedSeq[Scored[Double]]): TraversableOnce[Double] = {
           Vector(sols.head.solution)
         }
       }
@@ -83,8 +85,8 @@ class FunctionSerializabilityTest extends WordSpec with Matchers {
       }
 
       class M extends MutatorFunction[G]("d") {
-        override def mutate(sols: IndexedSeq[Scored[G]]): TraversableOnce[G] = {
-          Vector(sols.head.solution)
+        override def mutate(sol: G): G = {
+          sol
         }
       }
 
@@ -110,8 +112,8 @@ class FunctionSerializabilityTest extends WordSpec with Matchers {
       }
 
       class M extends MutatorFunction[CC]("d") {
-        override def mutate(sols: IndexedSeq[Scored[CC]]): TraversableOnce[CC] = {
-          Vector(sols.head.solution)
+        override def mutate(sol: CC): CC = {
+          sol
         }
       }
 
@@ -135,8 +137,8 @@ class FunctionSerializabilityTest extends WordSpec with Matchers {
       }
 
       class M extends MutatorFunction[Clazz]("d") {
-        override def mutate(sols: IndexedSeq[Scored[Clazz]]): TraversableOnce[Clazz] = {
-          Vector(sols.head.solution)
+        override def mutate(sol: Clazz): Clazz = {
+          sol
         }
       }
 

--- a/src/test/unit/scala/com/evvo/agent/ModifierAgentDefaultStrategyTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/ModifierAgentDefaultStrategyTest.scala
@@ -3,14 +3,14 @@ package com.evvo.agent
 import org.scalatest.{Matchers, WordSpec}
 import scala.concurrent.duration._
 
-class MutatorAgentDefaultStrategyTest extends WordSpec with Matchers {
+class ModifierAgentDefaultStrategyTest extends WordSpec with Matchers {
   "MutatorAgentDefaultStrategy" should {
     val smallPop = PopulationInformation(1000)
     val largePop = PopulationInformation(10000)
 
     "always wait 0ms" in {
-      assert(MutatorAgentDefaultStrategy().waitTime(smallPop) == 0.millis)
-      assert(MutatorAgentDefaultStrategy().waitTime(largePop) == 0.millis)
+      assert(ModifierAgentDefaultStrategy().waitTime(smallPop) == 0.millis)
+      assert(ModifierAgentDefaultStrategy().waitTime(largePop) == 0.millis)
     }
   }
 }

--- a/src/test/unit/scala/com/evvo/agent/ModifierFunctionTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/ModifierFunctionTest.scala
@@ -1,0 +1,19 @@
+package com.evvo.agent
+
+import com.evvo.island.population.Scored
+import org.scalatest.WordSpec
+
+class ModifierFunctionTest extends WordSpec{
+  "ModifierFunction" should {
+    "call its function on the input set" in {
+
+      val modifier = new ModifierFunction[Double]("Modifier") {
+        override def modify(sols: IndexedSeq[Scored[Double]]): TraversableOnce[Double] = {
+          Vector(3)
+        }
+      }
+      assert(modifier.modify(IndexedSeq[Scored[Double]]()) == Vector(3))
+    }
+  }
+
+}

--- a/src/test/unit/scala/com/evvo/agent/MutatorFunctionTest.scala
+++ b/src/test/unit/scala/com/evvo/agent/MutatorFunctionTest.scala
@@ -1,0 +1,24 @@
+package com.evvo.agent
+
+import com.evvo.island.population.Scored
+import org.scalatest.{Matchers, WordSpec}
+
+class MutatorFunctionTest extends WordSpec with Matchers {
+  "MutatorFunction" should {
+    "apply a one-to-one mapping" in {
+      val mutator = new MutatorFunction[Double]("Add1") {
+        override protected def mutate(sol: Double): Double = {
+          sol + 1
+        }
+      }
+
+      mutator.modify(Vector()).toVector should be(empty)
+      mutator.modify(Vector(Scored(Map(), 3d))).toVector should contain(4d)
+
+      val fourAndFive = mutator.modify(Vector(Scored(Map(), 3d), Scored(Map(), 4d))).toVector
+      fourAndFive should have length 2
+      fourAndFive should contain(4d)
+      fourAndFive should contain(5d)
+    }
+  }
+}


### PR DESCRIPTION
Also added Mutators and Crossover functions - these are convenience classes that make it easier to make standard mutator and crossover functions. They don't need a different agent because they can be converted to functions with the same signature as a standard Modifier.

Includes some misc cleanup of TODOs

Closes #90 