### PR TITLE
Use overrides to prevent duplication in AAgent

### DIFF
--- a/src/main/scala/io/evvo/agent/agent.scala
+++ b/src/main/scala/io/evvo/agent/agent.scala
@@ -23,10 +23,10 @@ trait Agent[Sol] {
   *               or slf4s interface.
   * @param name The name of this agent. Used for logging.
   */
-abstract class AAgent[Sol](private val strategy: AgentStrategy,
-                           private val population: Population[Sol],
+abstract class AAgent[Sol](protected val strategy: AgentStrategy,
+                           protected val population: Population[Sol],
                            protected val name: String)
-                          (private implicit val logger: LoggingAdapter)
+                          (implicit protected val logger: LoggingAdapter)
   extends Agent[Sol] {
 
   /** The number of  times this agent has run its function. */

--- a/src/main/scala/io/evvo/agent/creator.scala
+++ b/src/main/scala/io/evvo/agent/creator.scala
@@ -6,16 +6,15 @@ import io.evvo.island.population.Population
 import scala.concurrent.duration._
 
 
-/** An [[Agent]] that produces new solutions and adds them to the population.
+/** An [[io.evvo.agent.Agent]] that produces new solutions and adds them to the population.
   *
   * @param create The function that creates new solutions.
   */
-case class CreatorAgent[Sol](create: CreatorFunction[Sol],
-                             population: Population[Sol],
-                             strategy: AgentStrategy = CreatorAgentDefaultStrategy())
-                            (implicit val logger: LoggingAdapter)
+class CreatorAgent[Sol](create: CreatorFunction[Sol],
+                        population: Population[Sol],
+                        strategy: AgentStrategy = CreatorAgentDefaultStrategy())
+                       (implicit logger: LoggingAdapter)
   extends AAgent[Sol](strategy, population, create.name)(logger) {
-
   override protected def step(): Unit = {
     val toAdd = create.create()
     logger.debug(s"Created solutions, $toAdd , $this")
@@ -23,6 +22,15 @@ case class CreatorAgent[Sol](create: CreatorFunction[Sol],
   }
 
   override def toString: String = s"CreatorAgent[$name]"
+}
+
+object CreatorAgent {
+  /** @return A new [[io.evvo.agent.CreatorAgent]]. */
+  def apply[Sol](create: CreatorFunction[Sol],
+                 population: Population[Sol],
+                 strategy: AgentStrategy = CreatorAgentDefaultStrategy())
+                (implicit logger: LoggingAdapter): CreatorAgent[Sol] =
+    new CreatorAgent(create, population, strategy)
 }
 
 case class CreatorAgentDefaultStrategy() extends AgentStrategy {

--- a/src/main/scala/io/evvo/agent/deletor.scala
+++ b/src/main/scala/io/evvo/agent/deletor.scala
@@ -5,13 +5,14 @@ import io.evvo.island.population.Population
 
 import scala.concurrent.duration._
 
-/** Deletes solutions from the population.
+/** An [[io.evvo.agent.Agent]] that deletes solutions from the population.
+  *
   * @param delete A function that, given a set of solutions, tells you which to delete.
   */
-case class DeletorAgent[Sol](delete: DeletorFunction[Sol],
-                             population: Population[Sol],
-                             strategy: AgentStrategy = DeletorAgentDefaultStrategy())
-                            (implicit val logger: LoggingAdapter)
+class DeletorAgent[Sol](delete: DeletorFunction[Sol],
+                        population: Population[Sol],
+                        strategy: AgentStrategy = DeletorAgentDefaultStrategy())
+                       (implicit logger: LoggingAdapter)
   extends AAgent[Sol](strategy, population, delete.name)(logger) {
 
   override protected def step(): Unit = {
@@ -28,6 +29,16 @@ case class DeletorAgent[Sol](delete: DeletorFunction[Sol],
 
   override def toString: String = s"DeletorAgent[$name]"
 }
+
+object DeletorAgent {
+  /** @return a new [[io.evvo.agent.DeletorAgent]] */
+  def apply[Sol](delete: DeletorFunction[Sol],
+                 population: Population[Sol],
+                 strategy: AgentStrategy = DeletorAgentDefaultStrategy())
+                (implicit logger: LoggingAdapter): DeletorAgent[Sol] =
+    new DeletorAgent(delete, population, strategy)
+}
+
 
 case class DeletorAgentDefaultStrategy() extends AgentStrategy {
   override def waitTime(populationInformation: PopulationInformation): Duration = {

--- a/src/main/scala/io/evvo/agent/func.scala
+++ b/src/main/scala/io/evvo/agent/func.scala
@@ -19,6 +19,9 @@ abstract class CreatorFunction[Sol](name: String) extends NamedFunction(name) {
 }
 
 /** A function that derives a new set of solutions from some input set of solutions.
+  * See also [[io.evvo.agent.MutatorFunction]] and [[io.evvo.agent.CrossoverFunction]] for
+  * convenience classes that allow you to create functions for common tasks.
+  *
   * @param name                      This function's name
   * @param numInputs                 The number of solutions to request in the contents of each
   *                                  input set

--- a/src/main/scala/io/evvo/agent/modifier.scala
+++ b/src/main/scala/io/evvo/agent/modifier.scala
@@ -5,14 +5,15 @@ import io.evvo.island.population.Population
 
 import scala.concurrent.duration._
 
-/** Grabs some solutions from the population, creates new solutions based on the old ones, and
-  * adds the new ones to the population.
+/** An [[io.evvo.agent.Agent]] that grabs some solutions from the population, creates new solutions
+  * based on the old ones, and adds the new ones to the population.
+  *
   * @param modifier The function that generates new solutions from existing ones.
   */
-case class ModifierAgent[Sol](modifier: ModifierFunction[Sol],
-                              population: Population[Sol],
-                              strategy: AgentStrategy = ModifierAgentDefaultStrategy())
-                             (implicit val logger: LoggingAdapter)
+class ModifierAgent[Sol](modifier: ModifierFunction[Sol],
+                         population: Population[Sol],
+                         strategy: AgentStrategy = ModifierAgentDefaultStrategy())
+                        (implicit logger: LoggingAdapter)
   extends AAgent[Sol](strategy, population, modifier.name)(logger) {
 
   override protected def step(): Unit = {
@@ -27,6 +28,15 @@ case class ModifierAgent[Sol](modifier: ModifierFunction[Sol],
   }
 
   override def toString: String = s"MutatorAgent[$name]"
+}
+
+object ModifierAgent {
+  /** @return A new [[io.evvo.agent.ModifierAgent]]. */
+  def apply[Sol](modifier: ModifierFunction[Sol],
+                 population: Population[Sol],
+                 strategy: AgentStrategy = ModifierAgentDefaultStrategy())
+                (implicit logger: LoggingAdapter): ModifierAgent[Sol] =
+    new ModifierAgent[Sol](modifier, population, strategy)
 }
 
 case class ModifierAgentDefaultStrategy() extends AgentStrategy {


### PR DESCRIPTION
This includes making agents classes, instead of case classes. They have mutable state, and having them be case classes hides that a little. Companion objects are provided to keep the old construction API.