### PR TITLE
Updates to network topology usage

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ You probably don't need to build this - we build the image on every merge to mas
 For now, we only produce one docker image, which runs the RemoteActorSystem to listen for islands being sent by an IslandManager. To build this docker image, you have to build the jar, then run `docker build` using the top-level directory as the build context. Run this from the top level directory of evvo:
 ```bash 
 mvn clean package
-docker build --build-arg JAR_FILE=evvo-0.0.0-allinone.jar -t evvo:latest -f docker/Dockerfile .
+docker build --build-arg JAR_FILE=evvo_2.13-0.0.0-allinone.jar -t evvo:latest -f docker/Dockerfile .
 ```
 
 To run it:

--- a/src/main/scala/io/evvo/island/emigrationstrategy.scala
+++ b/src/main/scala/io/evvo/island/emigrationstrategy.scala
@@ -52,18 +52,14 @@ trait EmigrationTargetStrategy {
   def chooseTargets(numIslands: Int): Seq[Int]
 }
 
-class RoundRobinEmigrationTargetStrategy() extends EmigrationTargetStrategy {
-  var index = 0
+case class RoundRobinEmigrationTargetStrategy() extends EmigrationTargetStrategy {
+  // Incremented to 0 before it's returned, don't worry.
+  private var index = -1
 
   override def chooseTargets(numIslands: Int): Seq[Int] = {
-    val out = Seq(index)
     index = (index + 1) % numIslands
-    out
+    Seq(index)
   }
-}
-
-object RoundRobinEmigrationTargetStrategy {
-  def apply(): RoundRobinEmigrationTargetStrategy = new RoundRobinEmigrationTargetStrategy()
 }
 
 case class SendToAllEmigrationTargetStrategy() extends EmigrationTargetStrategy {

--- a/src/main/scala/io/evvo/island/immigrationstrategy.scala
+++ b/src/main/scala/io/evvo/island/immigrationstrategy.scala
@@ -16,7 +16,7 @@ trait ImmigrationStrategy {
 }
 
 /** Only allows new immigrants if they would advance the Pareto frontier on the island. */
-object ElitistImmigrationStrategy extends ImmigrationStrategy {
+case object ElitistImmigrationStrategy extends ImmigrationStrategy {
   override def filter[Sol](
       immigrants: Seq[Scored[Sol]],
       population: Population[Sol]
@@ -28,7 +28,7 @@ object ElitistImmigrationStrategy extends ImmigrationStrategy {
 }
 
 /** An immigration strategy that allows all immigrants. */
-object AllowAllImmigrationStrategy extends ImmigrationStrategy {
+case object AllowAllImmigrationStrategy extends ImmigrationStrategy {
   override def filter[Sol](
       immigrants: Seq[Scored[Sol]],
       population: Population[Sol]

--- a/src/main/scala/io/evvo/island/loggingstrategy.scala
+++ b/src/main/scala/io/evvo/island/loggingstrategy.scala
@@ -20,7 +20,8 @@ trait LoggingStrategy {
   def logPopulation(population: Population[_]): String
 }
 
-case class LogPopulationLoggingStrategy(durationBetweenLogs: FiniteDuration = 1.second) extends LoggingStrategy {
+case class LogPopulationLoggingStrategy(durationBetweenLogs: FiniteDuration = 1.second)
+    extends LoggingStrategy {
   override def logPopulation(population: Population[_]): String = {
     f"""
      |Size: ${population.getInformation().numSolutions}
@@ -28,7 +29,6 @@ case class LogPopulationLoggingStrategy(durationBetweenLogs: FiniteDuration = 1.
      """.stripMargin
   }
 }
-
 
 case class NullLoggingStrategy() extends LoggingStrategy {
   override def durationBetweenLogs: FiniteDuration = 1000.days

--- a/src/main/scala/io/evvo/island/population/networktopology.scala
+++ b/src/main/scala/io/evvo/island/population/networktopology.scala
@@ -16,7 +16,7 @@ trait NetworkTopology {
 /** Represents a connection from `from` to `to`. */
 case class Connection(from: Int, to: Int)
 
-case object RingNetworkTopology extends NetworkTopology {
+case class RingNetworkTopology() extends NetworkTopology {
   override def configure(numIslands: Int): Seq[Connection] = {
     if (numIslands == 1) {
       Seq()
@@ -31,13 +31,13 @@ case object RingNetworkTopology extends NetworkTopology {
   }
 }
 
-case object FullyConnectedNetworkTopology extends NetworkTopology {
+case class FullyConnectedNetworkTopology() extends NetworkTopology {
   override def configure(numIslands: Int): Seq[Connection] = {
     Vector.tabulate(numIslands, numIslands)(Connection).flatten.filterNot(c => c.from == c.to)
   }
 }
 
-case object StarNetworkTopology extends NetworkTopology {
+case class StarNetworkTopology() extends NetworkTopology {
   override def configure(numIslands: Int): Seq[Connection] = {
     // 0 is the center point, connect everything else
     Vector

--- a/src/test/integration/scala/io/evvo/LocalIslandManagerTest.scala
+++ b/src/test/integration/scala/io/evvo/LocalIslandManagerTest.scala
@@ -50,7 +50,7 @@ class LocalIslandManagerTest extends WordSpec with Matchers {
         .addModifier(mutator)
         .addDeletor(DeleteDominated[Solution]())
 
-      val manager = new LocalIslandManager(10, builder, FullyConnectedNetworkTopology)
+      val manager = new LocalIslandManager(10, builder, FullyConnectedNetworkTopology())
 
       manager.runBlocking(StopAfter(1000.millis))
 

--- a/src/test/unit/scala/io/evvo/island/IslandManagerTest.scala
+++ b/src/test/unit/scala/io/evvo/island/IslandManagerTest.scala
@@ -39,7 +39,7 @@ class IslandManagerTest extends WordSpec with Matchers {
         // simply constructing the manager registers the islands with each other
         val mgr = new IslandManager[Bitstring](
           Seq(island1, island2, island3),
-          FullyConnectedNetworkTopology)
+          FullyConnectedNetworkTopology())
         island1.immigrate(Seq(Scored(Map(), Seq(true))))
 
         mgr.runBlocking(StopAfter(1.second))

--- a/src/test/unit/scala/io/evvo/island/population/NetworkTopologyTest.scala
+++ b/src/test/unit/scala/io/evvo/island/population/NetworkTopologyTest.scala
@@ -5,9 +5,9 @@ import org.scalatest.{Matchers, WordSpec}
 class NetworkTopologyTest extends WordSpec with Matchers {
   "RingNetworkTopology" should {
     "connect islands in a ring" in {
-      RingNetworkTopology.configure(1).toSet shouldBe Set()
-      RingNetworkTopology.configure(2).toSet shouldBe Set(Connection(0, 1), Connection(1, 0))
-      RingNetworkTopology.configure(3).toSet shouldBe Set(
+      RingNetworkTopology().configure(1).toSet shouldBe Set()
+      RingNetworkTopology().configure(2).toSet shouldBe Set(Connection(0, 1), Connection(1, 0))
+      RingNetworkTopology().configure(3).toSet shouldBe Set(
         Connection(0, 1),
         Connection(1, 0),
         Connection(1, 2),
@@ -15,7 +15,7 @@ class NetworkTopologyTest extends WordSpec with Matchers {
         Connection(2, 0),
         Connection(0, 2))
 
-      RingNetworkTopology.configure(4).toSet shouldBe Set(
+      RingNetworkTopology().configure(4).toSet shouldBe Set(
         Connection(0, 1),
         Connection(1, 0),
         Connection(1, 2),
@@ -29,11 +29,11 @@ class NetworkTopologyTest extends WordSpec with Matchers {
 
   "FullyConnectedNetworkTopology" should {
     "connect all islands" in {
-      FullyConnectedNetworkTopology.configure(1).toSet shouldBe Set()
-      FullyConnectedNetworkTopology.configure(2).toSet shouldBe Set(
+      FullyConnectedNetworkTopology().configure(1).toSet shouldBe Set()
+      FullyConnectedNetworkTopology().configure(2).toSet shouldBe Set(
         Connection(0, 1),
         Connection(1, 0))
-      FullyConnectedNetworkTopology.configure(3).toSet shouldBe
+      FullyConnectedNetworkTopology().configure(3).toSet shouldBe
         Set(
           Connection(0, 1),
           Connection(1, 0),
@@ -46,12 +46,12 @@ class NetworkTopologyTest extends WordSpec with Matchers {
 
   "StarNetworkTopology" should {
     "connect all islands" in {
-      StarNetworkTopology.configure(1).toSet shouldBe Set()
-      StarNetworkTopology.configure(2).toSet shouldBe Set(Connection(0, 1), Connection(1, 0))
-      StarNetworkTopology.configure(3).toSet shouldBe
+      StarNetworkTopology().configure(1).toSet shouldBe Set()
+      StarNetworkTopology().configure(2).toSet shouldBe Set(Connection(0, 1), Connection(1, 0))
+      StarNetworkTopology().configure(3).toSet shouldBe
         Set(Connection(0, 1), Connection(1, 0), Connection(0, 2), Connection(2, 0))
 
-      StarNetworkTopology.configure(4).toSet shouldBe
+      StarNetworkTopology().configure(4).toSet shouldBe
         Set(
           Connection(0, 1),
           Connection(1, 0),


### PR DESCRIPTION
* All are now case classes, for extensibility and a common calling
interface
* Now defaults to fully connected, to not break backwards compatibility
* Update docker build command to point at right jar
* Make implementors of `EmigrationTargetStrategy` serializable (case objects)