### PR TITLE
Make new solutions with equal scores overwrite old ones

### DIFF
--- a/.idea/runConfigurations/All_Tests.xml
+++ b/.idea/runConfigurations/All_Tests.xml
@@ -5,28 +5,28 @@
     <option name="testKind" value="All in package" />
     <option name="classBuf">
       <list>
-        <option value="io.evvo.LocalEvvoTest" />
         <option value="io.evvo.ParetoFrontierTest" />
         <option value="io.evvo.ScoredTest" />
+        <option value="io.evvo.LocalEvvoTest" />
+        <option value="io.evvo.builtin.DeleteDominatedTest" />
         <option value="io.evvo.builtin.TreesAgentsTest" />
         <option value="io.evvo.builtin.TreesTest" />
         <option value="io.evvo.builtin.BitflipperTest" />
-        <option value="io.evvo.builtin.DeleteDominatedTest" />
-        <option value="io.evvo.island.AllowAllImmigrationStrategyTest" />
         <option value="io.evvo.island.EvvoIslandTest" />
         <option value="io.evvo.island.ElitistImmigrationStrategyTest" />
+        <option value="io.evvo.island.AllowAllImmigrationStrategyTest" />
         <option value="io.evvo.island.population.NetworkTopologyTest" />
         <option value="io.evvo.island.population.StandardPopulationTest" />
-        <option value="io.evvo.agent.CrossoverFunctionTest" />
-        <option value="io.evvo.agent.DeleteDominatedFunctionTest" />
-        <option value="io.evvo.agent.MutatorFunctionTest" />
-        <option value="io.evvo.agent.DeleteWorstHalfByRandomObjectiveTest" />
-        <option value="io.evvo.agent.AgentPropertiesTest" />
-        <option value="io.evvo.agent.ModifierFunctionTest" />
-        <option value="io.evvo.agent.DeletorAgentDefaultStrategyTest" />
-        <option value="io.evvo.agent.FunctionSerializabilityTest" />
         <option value="io.evvo.agent.ModifierAgentDefaultStrategyTest" />
         <option value="io.evvo.agent.CreatorAgentDefaultStrategyTest" />
+        <option value="io.evvo.agent.AgentPropertiesTest" />
+        <option value="io.evvo.agent.DeleteDominatedFunctionTest" />
+        <option value="io.evvo.agent.CrossoverFunctionTest" />
+        <option value="io.evvo.agent.DeletorAgentDefaultStrategyTest" />
+        <option value="io.evvo.agent.FunctionSerializabilityTest" />
+        <option value="io.evvo.agent.DeleteWorstHalfByRandomObjectiveTest" />
+        <option value="io.evvo.agent.ModifierFunctionTest" />
+        <option value="io.evvo.agent.MutatorFunctionTest" />
         <option value="unit.scala.io.evvo.migration.RedisMigrationTest" />
         <option value="unit.scala.io.evvo.migration.RedisMigrationTest" />
       </list>

--- a/src/main/scala/io/evvo/island/loggingstrategy.scala
+++ b/src/main/scala/io/evvo/island/loggingstrategy.scala
@@ -26,6 +26,7 @@ case class LogPopulationLoggingStrategy(durationBetweenLogs: FiniteDuration = 1.
     f"""
      |Size: ${population.getInformation().numSolutions}
      |Pareto Frontier: ${population.getParetoFrontier()}
+     |Solutions: ${population.getParetoFrontier().solutions.map(_.solution).mkString("\n")}
      """.stripMargin
   }
 }

--- a/src/main/scala/io/evvo/island/population/population.scala
+++ b/src/main/scala/io/evvo/island/population/population.scala
@@ -1,7 +1,11 @@
 package io.evvo.island.population
 
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
 import io.evvo.agent.PopulationInformation
-import io.evvo.island.utilities.log
+
+import scala.jdk.CollectionConverters._
 
 /** A population is the set of all solutions current in an evolutionary process. Currently,
   * the only extending class is StandardPopulation, but other classes may have different behavior,
@@ -54,17 +58,25 @@ case class StandardPopulation[Sol: Manifest](
     objectivesIter: Seq[Objective[Sol]],
 ) extends Population[Sol] {
   private val objectives = objectivesIter.toSet
-  private var population = Set[Scored[Sol]]()
+  private val population: java.util.Set[Scored[Sol]] =
+    Collections.newSetFromMap(new ConcurrentHashMap())
+
+  private def addSol(sol: Scored[Sol]): Unit = {
+    if (population.contains(sol)) {
+      population.remove(sol)
+    }
+    population.add(sol)
+  }
 
   override def addSolutions(solutions: Iterable[Sol]): Unit = {
-    population ++= solutions.iterator.map(score)
+    solutions.map(score).foreach(addSol)
 //    log.debug(
 //      f"Added ${solutions.iterator.size} solutions, new population size ${population.size}"
 //    )
   }
 
   override def addScoredSolutions(solutions: Iterable[Scored[Sol]]): Unit = {
-    population ++= solutions
+    solutions.foreach(addSol)
   }
 
   private def score(solution: Sol): Scored[Sol] = {
@@ -77,15 +89,15 @@ case class StandardPopulation[Sol: Manifest](
   }
 
   override def getSolutions(n: Int): IndexedSeq[Scored[Sol]] = {
-    util.Random.shuffle(this.population.toVector).take(n)
+    util.Random.shuffle(this.population.iterator().asScala.toVector).take(n)
   }
 
   override def deleteSolutions(solutions: Iterable[Scored[Sol]]): Unit = {
-    this.population --= solutions
+    solutions.foreach(this.population.remove)
   }
 
   override def getParetoFrontier(): ParetoFrontier[Sol] = {
-    ParetoFrontier(this.population)
+    ParetoFrontier(this.population.iterator().asScala.toSet)
   }
 
   override def getInformation(): PopulationInformation = {


### PR DESCRIPTION
@drassaby This makes it easier for modifiers that may not actually change fitness thresholds still apply to the same solution multiple times. The motivation comes from PushGP programs, where changing constants (e.x. 0 to 1) may not make a difference, but if changing 9 to 10 does make a difference, we want to allow the constants to drift while the population still moves.

Also, our previous implementation was not threadsafe, we want to use a synchronous map/set.