### PR TITLE
Bugfix: islands now stop their agents after a completed run

### DIFF
--- a/.idea/runConfigurations/All_Tests.xml
+++ b/.idea/runConfigurations/All_Tests.xml
@@ -5,28 +5,28 @@
     <option name="testKind" value="All in package" />
     <option name="classBuf">
       <list>
+        <option value="io.evvo.LocalEvvoTest" />
         <option value="io.evvo.ParetoFrontierTest" />
         <option value="io.evvo.ScoredTest" />
-        <option value="io.evvo.LocalEvvoTest" />
-        <option value="io.evvo.builtin.DeleteDominatedTest" />
-        <option value="io.evvo.builtin.TreesAgentsTest" />
         <option value="io.evvo.builtin.TreesTest" />
+        <option value="io.evvo.builtin.DeleteDominatedTest" />
         <option value="io.evvo.builtin.BitflipperTest" />
-        <option value="io.evvo.island.EvvoIslandTest" />
+        <option value="io.evvo.builtin.TreesAgentsTest" />
         <option value="io.evvo.island.ElitistImmigrationStrategyTest" />
+        <option value="io.evvo.island.EvvoIslandTest" />
         <option value="io.evvo.island.AllowAllImmigrationStrategyTest" />
         <option value="io.evvo.island.population.NetworkTopologyTest" />
         <option value="io.evvo.island.population.StandardPopulationTest" />
+        <option value="io.evvo.agent.MutatorFunctionTest" />
         <option value="io.evvo.agent.ModifierAgentDefaultStrategyTest" />
-        <option value="io.evvo.agent.CreatorAgentDefaultStrategyTest" />
-        <option value="io.evvo.agent.AgentPropertiesTest" />
-        <option value="io.evvo.agent.DeleteDominatedFunctionTest" />
-        <option value="io.evvo.agent.CrossoverFunctionTest" />
+        <option value="io.evvo.agent.ModifierFunctionTest" />
         <option value="io.evvo.agent.DeletorAgentDefaultStrategyTest" />
         <option value="io.evvo.agent.FunctionSerializabilityTest" />
+        <option value="io.evvo.agent.AgentPropertiesTest" />
+        <option value="io.evvo.agent.CreatorAgentDefaultStrategyTest" />
         <option value="io.evvo.agent.DeleteWorstHalfByRandomObjectiveTest" />
-        <option value="io.evvo.agent.ModifierFunctionTest" />
-        <option value="io.evvo.agent.MutatorFunctionTest" />
+        <option value="io.evvo.agent.DeleteDominatedFunctionTest" />
+        <option value="io.evvo.agent.CrossoverFunctionTest" />
         <option value="unit.scala.io.evvo.migration.RedisMigrationTest" />
         <option value="unit.scala.io.evvo.migration.RedisMigrationTest" />
       </list>

--- a/src/main/scala/io/evvo/agent/agent.scala
+++ b/src/main/scala/io/evvo/agent/agent.scala
@@ -65,12 +65,6 @@ abstract class AAgent[Sol](
           }
           Thread.sleep(waitTime.toMillis)
 
-          // this is arbitrary
-//          if (numInvocations % 1000 == 0) {
-//            val nextInformation = population.getInformation()
-//            waitTime = strategy.waitTime(nextInformation)
-//            log.debug(s"${name}: Waiting for ${waitTime}")
-//          }
           if (numInvocations % 100000 == 0) {
             log.debug(s"${this}: ${name} hit ${numInvocations} invocations")
           }

--- a/src/main/scala/io/evvo/island/EvolutionaryProcess.scala
+++ b/src/main/scala/io/evvo/island/EvolutionaryProcess.scala
@@ -1,7 +1,7 @@
 package io.evvo.island
 
 import io.evvo.agent.AgentStatus
-import io.evvo.island.population.{ParetoFrontier, Scored}
+import io.evvo.island.population.ParetoFrontier
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -29,10 +29,6 @@ trait EvolutionaryProcess[Sol] {
 
   def immigrate(): Unit
   def emigrate(): Unit
-
-  /** Sends a poison pill to the evolutionary process.
-    */
-  def poisonPill(): Unit
 
   /** @return The status of every agent that is part of this evolutionary process.
     */

--- a/src/main/scala/io/evvo/island/island.scala
+++ b/src/main/scala/io/evvo/island/island.scala
@@ -66,6 +66,7 @@ class EvvoIsland[Sol: Manifest](
       immigrationExecutor.shutdownNow()
       emigrationExecutor.shutdownNow()
       loggingExecutor.shutdownNow()
+      allAgents.foreach(_.stop())
       paretoFrontierRecorder.record(this.currentParetoFrontier())
     }
   }

--- a/src/main/scala/io/evvo/island/island.scala
+++ b/src/main/scala/io/evvo/island/island.scala
@@ -97,14 +97,6 @@ class EvvoIsland[Sol: Manifest](
     pop.getParetoFrontier()
   }
 
-  override def poisonPill(): Unit = {
-    stop()
-  }
-
-  private def stop(): Unit = {
-    allAgents.foreach(_.stop())
-  }
-
   override def agentStatuses(): Seq[AgentStatus] = allAgents.map(_.status())
 }
 


### PR DESCRIPTION
Also removed `stop` and `poisonPill` from the `EvolutionaryProcess` trait (and `EvvoIsland` implementations) since they are unused hold overs from the Akka days